### PR TITLE
Fix PR #1 review issues: correct folder flags, optimize searchMessages, add unreadOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Thunderbird extension embeds a local HTTP server. The Node.js bridge transla
 |------|-------------|
 | `listAccounts` | List all email accounts and their identities |
 | `listFolders` | Browse folder tree with message counts — filter by account or subtree |
-| `searchMessages` | Find emails by subject, sender, recipient, date range, or within a specific folder |
+| `searchMessages` | Find emails by subject, sender, recipient, date range, read status, or within a specific folder |
 | `getMessage` | Read full email content with optional attachment saving to disk |
 | `getRecentMessages` | Get recent messages with date and unread filtering |
 | `updateMessage` | Mark read/unread, flag/unflag, move between folders, or trash |


### PR DESCRIPTION
## Summary

Addresses the review feedback from [PR #1](https://github.com/TKasperczyk/thunderbird-mcp/pull/1):

- **Fixed folder flag values in `listFolders`** — the original PR used `0x1000` for Virtual (actually Inbox) and `0x00000800` for Templates (actually Queue/Outbox). This adds type detection using the correct values from [nsMsgFolderFlags.idl](https://searchfox.org/comm-central/source/mailnews/base/public/nsMsgFolderFlags.idl): Virtual=`0x20`, Inbox=`0x1000`, Sent=`0x200`, Drafts=`0x400`, Trash=`0x100`, Templates=`0x400000`, Queue=`0x800`, Junk=`0x40000000`, Archive=`0x4000`
- **Virtual folder filtering** — `listFolders` now skips virtual/search folders (`0x00000020`) to avoid duplicate entries from unified inbox or search folders
- **Added `unreadOnly` parameter to `searchMessages`** — so it can also filter by read status, in addition to query/date/folder
- **Optimized `searchMessages` hot path** — moved cheap date/boolean filters before MIME decode + `toLowerCase()` string work. Previously every message paid for 4x string decode+lowercase even if immediately filtered by date. Now messages outside the date range skip string work entirely
- **Preserved `getRecentMessages` as standalone tool** — provides sane defaults (`daysBack: 7`, no required params) and a simpler interface for the common "show me what's new" use case

## Test plan

- [x] `listFolders` returns correct `type` field (inbox, drafts, sent, trash, junk, archive, folder)
- [x] Virtual folders are excluded from `listFolders` results
- [x] `searchMessages` with `unreadOnly: true` filters out read messages
- [x] `searchMessages` with `unreadOnly: false` returns all messages
- [x] `getRecentMessages` still works as standalone tool
- [x] `listAccounts` unchanged, still works
- [x] Tested against a live Thunderbird instance with IMAP account

🤖 Generated with [Claude Code](https://claude.com/claude-code)