### PR TITLE
fix: proper UTF-8 encoding via TextEncoder, remove sanitizeForJson

### DIFF
--- a/extension/httpd.sys.mjs
+++ b/extension/httpd.sys.mjs
@@ -3818,7 +3818,18 @@ Response.prototype = {
     }
 
     var dataAsString = String(data);
-    this.bodyOutputStream.write(dataAsString, dataAsString.length);
+    // Encode as UTF-8 to correctly handle non-ASCII characters.
+    // The default bodyOutputStream.write() only takes the low byte of each
+    // UTF-16 code unit, silently discarding the high byte and corrupting
+    // any non-Latin-1 text (e.g., CJK characters).
+    var encoder = new TextEncoder();
+    var utf8Bytes = encoder.encode(dataAsString);
+    var binaryChars = new Array(utf8Bytes.length);
+    for (var i = 0; i < utf8Bytes.length; i++) {
+      binaryChars[i] = String.fromCharCode(utf8Bytes[i]);
+    }
+    var binaryStr = binaryChars.join('');
+    this.bodyOutputStream.write(binaryStr, binaryStr.length);
   },
 
   //

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,9 @@ echo "Building Thunderbird MCP extension..."
 # Create dist directory
 mkdir -p "$DIST_DIR"
 
+# Remove old XPI to ensure a clean build
+rm -f "$DIST_DIR/thunderbird-mcp.xpi"
+
 # Package extension
 cd "$EXTENSION_DIR"
 zip -r "$DIST_DIR/thunderbird-mcp.xpi" . -x "*.DS_Store" -x "*.git*"


### PR DESCRIPTION
## Summary

- **Root cause fix**: `httpd.sys.mjs`'s `write()` method uses `bodyOutputStream.write()` which treats JavaScript strings as Latin-1, only preserving the low byte of each UTF-16 code unit. This silently corrupts any non-Latin-1 text (CJK characters, accented characters, etc.)
- **Fix**: Use `TextEncoder` to properly encode strings as UTF-8 before writing to the output stream
- **Cleanup**: Remove `sanitizeForJson()` function and all ~20 call sites — no longer needed since `JSON.stringify` already escapes control characters, and `TextEncoder` handles encoding correctly

## Changes

| File | Change |
|------|--------|
| `extension/httpd.sys.mjs` | `TextEncoder`-based `write()` for correct UTF-8 encoding |
| `extension/mcp_server/api.js` | Remove `sanitizeForJson` function and all call sites (-77 lines) |
| `scripts/build.sh` | Clean old XPI before rebuild to prevent stale artifacts |

## Testing

Verified all tools return correct CJK text after changes:
- `listFolders` — Chinese folder names (垃圾规则起效, 身份证, 会议, 夏老师, etc.)
- `searchMessages` — Chinese subjects and authors
- `getRecentMessages` — Chinese subjects and folder paths
- `getMessage` — Chinese email body content
- `listAccounts` — account names

## Context

`sanitizeForJson` was introduced in PR #12 as a workaround for the Latin-1 encoding issue. This PR fixes the root cause, making the workaround unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)