### PR TITLE
fix: handle MCP initialize handshake in bridge

### DIFF
--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -64,6 +64,19 @@ async function handleMessage(line) {
     return null;
   }
 
+  // Handle MCP protocol handshake locally — Thunderbird extension doesn't support these
+  if (message.method === 'initialize') {
+    return {
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'thunderbird-mcp', version: '1.0.0' }
+      }
+    };
+  }
+
   return forwardToThunderbird(message);
 }
 


### PR DESCRIPTION
## Summary
- The bridge forwards all JSON-RPC messages to the Thunderbird extension, including `initialize`
- The extension doesn't handle `initialize` and returns plain text `"Unknown method: initialize"`, which fails JSON parsing
- MCP clients like Claude Code that require the standard handshake report the server as failed on startup

This PR handles `initialize` locally in the bridge, returning the expected MCP protocol response.

Fixes #18

## Test plan
- Verified the full MCP handshake (initialize → notifications/initialized → tools/list) succeeds through the bridge
- Confirmed tools/list and tool calls still route to Thunderbird correctly