### PR TITLE
fix: prevent GC of nsITimer in composeMail, set attachment size

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -21,6 +21,8 @@ const resProto = Cc[
 const MCP_PORT = 8765;
 // Keep references to active attach timers to prevent GC before they fire.
 const _attachTimers = new Set();
+// Delay before injecting attachments into a newly opened compose window.
+const COMPOSE_WINDOW_LOAD_DELAY_MS = 1500;
 const DEFAULT_MAX_RESULTS = 50;
 const MAX_SEARCH_RESULTS_CAP = 200;
 const SEARCH_COLLECTION_CAP = 1000;
@@ -554,6 +556,13 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               return null;
             }
 
+            /** Creates an nsIFile instance for the given path. */
+            function createLocalFile(path) {
+              const file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+              file.initWithPath(path);
+              return file;
+            }
+
             /**
              * Converts local file paths to attachment descriptors, validating existence upfront.
              * Returns { descs: [{url, name, size}], failed: string[] }
@@ -565,8 +574,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               if (!filePaths || !Array.isArray(filePaths)) return { descs, failed };
               for (const filePath of filePaths) {
                 try {
-                  const file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
-                  file.initWithPath(filePath);
+                  const file = createLocalFile(filePath);
                   if (file.exists()) {
                     descs.push({ url: Services.io.newFileURI(file).spec, name: file.leafName, size: file.fileSize });
                   } else {
@@ -612,7 +620,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     }
                   } catch(e) {}
                 }
-              }, 1500, Ci.nsITimer.TYPE_ONE_SHOT);
+              }, COMPOSE_WINDOW_LOAD_DELAY_MS, Ci.nsITimer.TYPE_ONE_SHOT);
             }
 
             function escapeHtml(s) {
@@ -1174,8 +1182,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     }
 
                     function ensureAttachmentDir(sanitizedId) {
-                      const root = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
-                      root.initWithPath("/tmp/thunderbird-mcp");
+                      const root = createLocalFile("/tmp/thunderbird-mcp");
                       try {
                         root.create(Ci.nsIFile.DIRECTORY_TYPE, 0o755);
                       } catch (e) {


### PR DESCRIPTION
## Problem

When calling \`sendMail\` / \`replyToMessage\` / \`forwardMessage\` with attachments, the attachments were silently not added to the compose window.

Root cause: \`nsITimer\` was stored in a local variable. After the function returned normally, the variable went out of scope and the timer was garbage collected before its callback fired.

This explained a puzzling observation: a version with a **subsequent JS error** (\`failedAttachments is not defined\`) actually *worked* — because the error kept the JS engine busy past the timer registration, preventing GC.

A secondary issue: attachment size was shown as 0 bytes because \`att.size\` was never set.

## Fix

- **\`_attachTimers\` Set**: replace the single \`_attachTimer\` ref with a module-level \`Set\` so concurrent compose operations each keep their own timer alive.
- **\`injectAttachmentsAsync(attachDescs)\`**: shared helper used by all three compose functions. Accepts \`{ url, name, size?, contentType? }\` descriptors to handle both local file paths and original message attachment URLs (needed for forward).
- **\`filePathsToAttachDescs(filePaths)\`**: validates file existence upfront and returns \`{ descs, failed }\`. Missing files are reported synchronously in the tool response.
- **Remove dead \`addAttachments(composeFields, ...)\`**: this function silently dropped attachments on \`nsIMsgCompType.New\` and is fully replaced.
- **Fix \`replyToMessage\` and \`forwardMessage\`**: both now use \`injectAttachmentsAsync\`. Forward passes original message attachments alongside user-specified files.
- **\`COMPOSE_WINDOW_LOAD_DELAY_MS\`**: named constant for the 1500ms delay.
- **\`createLocalFile(path)\`**: small helper to avoid repeating the \`nsIFile\` instantiation pattern.

## Testing

Verified all three functions with a real attachment:
- \`sendMail\` + attachment ✅
- \`replyToMessage\` + attachment ✅  
- \`forwardMessage\` + attachment ✅

Attachment appears in compose window with correct filename and size.