### PR TITLE
fix: extract body from root message/rfc822 MIME nodes

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1219,12 +1219,15 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 if (text) return text;
               } catch { /* fall through */ }
               try {
-                function findBody(part) {
+                function findBody(part, isRoot = false) {
                   const ct = ((part.contentType || "").split(";")[0] || "").trim().toLowerCase();
-                  // Skip nested messages (attached emails) -- their body is not ours
-                  if (ct === "message/rfc822") return null;
-                  if (ct === "text/plain" && part.body) return { text: part.body, isHtml: false };
-                  if (ct === "text/html" && part.body) return { text: part.body, isHtml: true };
+                  // Skip nested messages (attached emails) -- their body is not ours.
+                  // Allow the root message/rfc822 so we recurse into its children.
+                  if (ct === "message/rfc822" && !isRoot) return null;
+                  if (ct !== "message/rfc822") {
+                    if (ct === "text/plain" && part.body) return { text: part.body, isHtml: false };
+                    if (ct === "text/html" && part.body) return { text: part.body, isHtml: true };
+                  }
                   if (part.parts) {
                     let htmlFallback = null;
                     for (const sub of part.parts) {
@@ -1236,7 +1239,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   }
                   return null;
                 }
-                const found = findBody(aMimeMsg);
+                const found = findBody(aMimeMsg, true);
                 if (found) return found.isHtml ? stripHtml(found.text) : found.text;
               } catch { /* give up */ }
               return "";


### PR DESCRIPTION
## Problem

`getMessage` returns `(Could not extract body text)` for certain HTML-only emails.

`extractPlainTextBody` has two paths: `coerceBodyToPlaintext()` (primary) and a MIME tree walk (fallback). The fallback's `findBody` function unconditionally returns `null` for `message/rfc822` parts — intended to skip nested attached emails. However, `MsgHdrToMimeMessage` wraps the root email itself in `message/rfc822`, so when `coerceBodyToPlaintext()` fails the tree walk bails at the root without ever reaching the `text/html` child.

This affects heavily templated HTML-only emails (recruitment platforms like PageUp, marketing systems) where `coerceBodyToPlaintext()` returns empty.

## Fix

Add an `isRoot` parameter to `findBody`. The root `message/rfc822` node recurses into its children; nested `message/rfc822` parts are still skipped.

## Example

MIME structure of an affected email:
```
message/rfc822 (body=0, parts=1)
  text/html (body=3390, parts=0) [1]
```

Before: `findBody` hits `message/rfc822`, returns `null`. Body extraction fails.
After: `findBody` skips the root's own body but recurses into `parts`, finds the `text/html` child, and returns stripped plain text.