### PR TITLE
security: fix XSS, DoS, symlink, and permission issues

### DIFF
--- a/extension/httpd.sys.mjs
+++ b/extension/httpd.sys.mjs
@@ -1498,6 +1498,12 @@ RequestReader.prototype = {
           : 0;
         dumpn("_processHeaders, Content-length=" + this._contentLength);
 
+        // Reject oversized request bodies before buffering into memory.
+        // 10 MB is generous for JSON-RPC MCP requests.
+        if (this._contentLength > 10 * 1024 * 1024) {
+          throw HTTP_413;
+        }
+
         this._state = READER_IN_BODY;
       }
       return done;

--- a/extension/httpd.sys.mjs
+++ b/extension/httpd.sys.mjs
@@ -3441,6 +3441,9 @@ ServerHandler.prototype = {
   /**
    * Contains handlers for the default set of URIs contained in this server.
    */
+  // /trace endpoint removed — it echoed all request headers (including
+  // Authorization tokens) without authentication, enabling token leakage
+  // to any local process.
   _defaultPaths: {
     "/": function (metadata, response) {
       response.setStatusLine(metadata.httpVersion, 200, "OK");
@@ -3456,39 +3459,6 @@ ServerHandler.prototype = {
                         files!</p>\
                     </body>\
                   </html>";
-
-      response.bodyOutputStream.write(body, body.length);
-    },
-
-    "/trace": function (metadata, response) {
-      response.setStatusLine(metadata.httpVersion, 200, "OK");
-      response.setHeader("Content-Type", "text/plain;charset=utf-8", false);
-
-      var body =
-        "Request-URI: " +
-        metadata.scheme +
-        "://" +
-        metadata.host +
-        ":" +
-        metadata.port +
-        metadata.path +
-        "\n\n";
-      body += "Request (semantically equivalent, slightly reformatted):\n\n";
-      body += metadata.method + " " + metadata.path;
-
-      if (metadata.queryString) {
-        body += "?" + metadata.queryString;
-      }
-
-      body += " HTTP/" + metadata.httpVersion + "\r\n";
-
-      var headEnum = metadata.headers;
-      while (headEnum.hasMoreElements()) {
-        var fieldName = headEnum
-          .getNext()
-          .QueryInterface(Ci.nsISupportsString).data;
-        body += fieldName + ": " + metadata.getHeader(fieldName) + "\r\n";
-      }
 
       response.bodyOutputStream.write(body, body.length);
     },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -50,7 +50,5 @@
     "accountsFolders",
     "compose"
   ],
-  "web_accessible_resources": [
-    "httpd.sys.mjs"
-  ]
+  "web_accessible_resources": []
 }

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -3024,7 +3024,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                           file.append(safeName);
 
                           try {
-                            file.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0o644);
+                            file.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0o600);
                           } catch (e) {
                             info.error = `Failed to create file: ${e}`;
                             done();
@@ -4681,13 +4681,34 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             server.registerPathHandler("/", (req, res) => {
               res.processAsync();
 
-              if (req.method !== "POST") {
-                res.setStatusLine("1.1", 200, "OK");
+              // Verify auth token on ALL requests (including non-POST) to
+              // prevent unauthenticated probing of the server.
+              let reqToken = "";
+              try {
+                reqToken = req.getHeader("Authorization") || "";
+              } catch {
+                // getHeader throws if header is missing in httpd.sys.mjs
+              }
+              if (!timingSafeEqual(reqToken, `Bearer ${authToken}`)) {
+                res.setStatusLine("1.1", 403, "Forbidden");
                 res.setHeader("Content-Type", "application/json; charset=utf-8", false);
                 res.write(JSON.stringify({
                   jsonrpc: "2.0",
                   id: null,
-                  error: { code: -32600, message: "Invalid Request" }
+                  error: { code: -32600, message: "Invalid or missing auth token" }
+                }));
+                res.finish();
+                return;
+              }
+
+              if (req.method !== "POST") {
+                res.setStatusLine("1.1", 405, "Method Not Allowed");
+                res.setHeader("Allow", "POST", false);
+                res.setHeader("Content-Type", "application/json; charset=utf-8", false);
+                res.write(JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: null,
+                  error: { code: -32600, message: "Method not allowed" }
                 }));
                 res.finish();
                 return;
@@ -4707,25 +4728,6 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   jsonrpc: "2.0",
                   id: null,
                   error: { code: -32600, message: "Request body too large" }
-                }));
-                res.finish();
-                return;
-              }
-
-              // Verify auth token from Authorization header
-              let reqToken = "";
-              try {
-                reqToken = req.getHeader("Authorization") || "";
-              } catch {
-                // getHeader throws if header is missing in httpd.sys.mjs
-              }
-              if (!timingSafeEqual(reqToken, `Bearer ${authToken}`)) {
-                res.setStatusLine("1.1", 403, "Forbidden");
-                res.setHeader("Content-Type", "application/json; charset=utf-8", false);
-                res.write(JSON.stringify({
-                  jsonrpc: "2.0",
-                  id: null,
-                  error: { code: -32600, message: "Invalid or missing auth token" }
                 }));
                 res.finish();
                 return;

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -25,6 +25,7 @@ const _attachTimers = new Set();
 // Track temp files created for inline base64 attachments (cleaned up on shutdown).
 const _tempAttachFiles = new Set();
 const MAX_BASE64_SIZE = 25 * 1024 * 1024; // 25 MB limit for inline base64 data (encoded)
+const MAX_REQUEST_BODY = 10 * 1024 * 1024; // 10 MB limit for incoming HTTP request bodies
 let _tempFileCounter = 0;
 // Delay before injecting attachments into a newly opened compose window.
 const COMPOSE_WINDOW_LOAD_DELAY_MS = 1500;
@@ -849,6 +850,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               tmpDir.append("thunderbird-mcp");
               if (!tmpDir.exists()) {
                 tmpDir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
+              } else if (tmpDir.isSymlink()) {
+                throw new Error("thunderbird-mcp tmp directory is a symlink — refusing to write connection info");
               }
               const connFile = tmpDir.clone();
               connFile.append("connection.json");
@@ -1488,7 +1491,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
 
             function escapeHtml(s) {
-              return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+              return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
             }
 
             function stripHtml(html) {
@@ -2966,7 +2969,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       const root = Services.dirsvc.get("TmpD", Ci.nsIFile);
                       root.append("thunderbird-mcp");
                       try {
-                        root.create(Ci.nsIFile.DIRECTORY_TYPE, 0o755);
+                        root.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
                       } catch (e) {
                         if (!root.exists() || !root.isDirectory()) throw e;
                         // already exists, fine
@@ -2974,7 +2977,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       const dir = root.clone();
                       dir.append(sanitizedId);
                       try {
-                        dir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o755);
+                        dir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
                       } catch (e) {
                         if (!dir.exists() || !dir.isDirectory()) throw e;
                         // already exists, fine
@@ -4685,6 +4688,25 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   jsonrpc: "2.0",
                   id: null,
                   error: { code: -32600, message: "Invalid Request" }
+                }));
+                res.finish();
+                return;
+              }
+
+              // Reject oversized request bodies to prevent memory exhaustion
+              let contentLength = 0;
+              try {
+                contentLength = parseInt(req.getHeader("Content-Length"), 10) || 0;
+              } catch {
+                // Header missing — will be 0
+              }
+              if (contentLength > MAX_REQUEST_BODY) {
+                res.setStatusLine("1.1", 413, "Payload Too Large");
+                res.setHeader("Content-Type", "application/json; charset=utf-8", false);
+                res.write(JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: null,
+                  error: { code: -32600, message: "Request body too large" }
                 }));
                 res.finish();
                 return;

--- a/extension/options.js
+++ b/extension/options.js
@@ -99,7 +99,10 @@ async function loadAccountAccess() {
     saveBtn.disabled = false;
     saveStatus.textContent = "";
   } catch (e) {
-    accountList.innerHTML = "<li>Error loading accounts: " + e.message + "</li>";
+    accountList.innerHTML = "";
+    const li = document.createElement("li");
+    li.textContent = "Error loading accounts: " + e.message;
+    accountList.appendChild(li);
   }
 }
 
@@ -215,7 +218,10 @@ async function loadToolAccess() {
     saveToolsBtn.disabled = false;
     saveToolsStatus.textContent = "";
   } catch (e) {
-    toolList.innerHTML = "<li>Error loading tools: " + e.message + "</li>";
+    toolList.innerHTML = "";
+    const li = document.createElement("li");
+    li.textContent = "Error loading tools: " + e.message;
+    toolList.appendChild(li);
   }
 }
 

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -81,10 +81,13 @@ function writeOutput(data) {
 function sanitizeJson(data) {
   // Remove control chars except \n, \r, \t
   let sanitized = data.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
-  // Escape raw newlines/carriage returns/tabs that aren't already escaped
-  sanitized = sanitized.replace(/(?<!\\)\r/g, '\\r');
-  sanitized = sanitized.replace(/(?<!\\)\n/g, '\\n');
-  sanitized = sanitized.replace(/(?<!\\)\t/g, '\\t');
+  // Escape raw newlines/carriage returns/tabs that aren't already escaped.
+  // Match an even number of backslashes (including zero) before the control
+  // char so we don't double-escape already-escaped sequences like \n, but
+  // do escape after literal backslash pairs like \\\n (escaped-backslash + raw newline).
+  sanitized = sanitized.replace(/((?:^|[^\\])(?:\\\\)*)\r/gm, '$1\\r');
+  sanitized = sanitized.replace(/((?:^|[^\\])(?:\\\\)*)\n/gm, '$1\\n');
+  sanitized = sanitized.replace(/((?:^|[^\\])(?:\\\\)*)\t/gm, '$1\\t');
   return sanitized;
 }
 
@@ -196,6 +199,9 @@ async function forwardToThunderbird(message, _retried) {
 
   if (!connInfo.port || !connInfo.token) {
     throw new Error('Invalid connection file: missing port or token');
+  }
+  if (typeof connInfo.port !== 'number' || connInfo.port < 1 || connInfo.port > 65535 || !Number.isInteger(connInfo.port)) {
+    throw new Error('Invalid connection file: port must be an integer between 1 and 65535');
   }
 
   const { port, token } = connInfo;


### PR DESCRIPTION
## Summary

Fixes 11 security issues found during a comprehensive audit (including hidden unicode scan).

### Commit 1: Core fixes
- **XSS in options.js** (Medium): Error messages were concatenated into `innerHTML`, allowing potential script injection. Replaced with `textContent` via DOM API.
- **Pre-auth memory exhaustion DoS** (Medium): No request body size limit — any local process could send a huge POST to exhaust Thunderbird's memory. Added 10 MB limit in both `httpd.sys.mjs` (pre-buffer rejection via HTTP 413) and the `api.js` handler (defense-in-depth).
- **Symlink attack on tmp directory** (Medium): `writeConnectionInfo` didn't check if `/tmp/thunderbird-mcp` was a symlink before writing. Added `isSymlink()` check.
- **Attachment dirs world-readable** (Low): `ensureAttachmentDir` created directories with `0o755` while other temp dirs used `0o700`. Fixed to `0o700`.
- **Incomplete `escapeHtml`** (Low): Missing `"` and `'` escaping. Added `&quot;` and `&#39;`.
- **Connection file port not validated** (Low): Bridge accepted any truthy value for port. Added integer range validation (1-65535).
- **`sanitizeJson` double-backslash handling** (Low): Lookbehind didn't handle double-escaped backslashes correctly. Replaced with capturing-group approach.

### Commit 2: Additional findings from deep review
- **Unauthenticated `/trace` endpoint** (Medium): `httpd.sys.mjs` had a default `/trace` handler that echoed all request headers — including the `Authorization` bearer token — without any authentication. Removed entirely.
- **Auth bypass on non-POST requests** (Low): Non-POST requests returned 200 OK without checking auth, allowing unauthenticated server probing. Moved auth check before method check; non-POST now returns 405 with `Allow: POST` header.
- **`web_accessible_resources` exposure** (Low): `httpd.sys.mjs` was listed in `web_accessible_resources` but is loaded via `resource://` protocol. Removed to prevent extension fingerprinting.
- **Saved attachment files world-readable** (Low): `file.createUnique` used `0o644`. Fixed to `0o600`.

### Also confirmed clean
- **No hidden unicode characters** — exhaustive scan for bidi overrides, zero-width chars, homoglyphs, Cyrillic, fullwidth, tag characters found nothing malicious.

## Test plan

- [x] All 275 existing tests pass
- [ ] Verify options page error rendering still works with DOM API approach
- [ ] Test oversized POST (>10 MB) returns 413 instead of consuming memory
- [ ] Verify connection file writing fails if tmp dir is a symlink
- [ ] Verify saved attachments directory and files have 0o700/0o600 permissions
- [ ] Verify GET request to server returns 403 (not 200) without auth token
- [ ] Verify /trace endpoint returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)