### PR TITLE
fix: Flatpak Thunderbird path detection for bridge and install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ Add to your MCP client config (e.g. `~/.claude.json` for Claude Code):
 }
 ```
 
+### Flatpak Installation
+
+Flatpak users of Thunderbird don't need to tweak anything: the bridge now looks for the Flatpak runtime connection file under `~/.var/app/org.mozilla.Thunderbird/.thunderbird/.../thunderbird-mcp/connection.json` before falling back to the standard temporary directory. If you prefer to control the file directly (for example when the runtime directory is non-standard), set the `THUNDERBIRD_MCP_CONNECTION_FILE` environment variable to the JSON file path.
+
+Claude Code (~/.claude.json):
+```json
+"thunderbird-mail": {
+  "command": "node",
+  "args": ["/path/to/mcp-bridge.cjs"],
+  "env": {
+    "THUNDERBIRD_MCP_CONNECTION_FILE": "/run/user/1000/app/org.mozilla.Thunderbird/thunderbird-mcp/connection.json"
+  }
+}
+```
+
+Codex (~/.codex/config.toml):
+```toml
+[mcp_servers.thunderbird-mail]
+command = "node"
+args = ["/path/to/mcp-bridge.cjs"]
+env = { THUNDERBIRD_MCP_CONNECTION_FILE = "/run/user/1000/app/org.mozilla.Thunderbird/thunderbird-mcp/connection.json" }
+```
+
 That's it. Your AI can now access Thunderbird.
 
 ---

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Add to your MCP client config (e.g. `~/.claude.json` for Claude Code):
 
 ### Flatpak Installation
 
-Flatpak users of Thunderbird don't need to tweak anything: the bridge now looks for the Flatpak runtime connection file under `~/.var/app/org.mozilla.Thunderbird/.thunderbird/.../thunderbird-mcp/connection.json` before falling back to the standard temporary directory. If you prefer to control the file directly (for example when the runtime directory is non-standard), set the `THUNDERBIRD_MCP_CONNECTION_FILE` environment variable to the JSON file path.
+Flatpak users of Thunderbird don't need to tweak anything: the bridge now automatically detects the Flatpak runtime connection file at `$XDG_RUNTIME_DIR/app/org.mozilla.Thunderbird/thunderbird-mcp/connection.json` before falling back to the standard temporary directory. If you prefer to control the file directly (for example when the runtime directory is non-standard), set the `THUNDERBIRD_MCP_CONNECTION_FILE` environment variable to the JSON file path.
 
 Claude Code (~/.claude.json):
 ```json

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -14,10 +14,36 @@ const os = require('os');
 
 const THUNDERBIRD_HOSTS = ['127.0.0.1'];
 const REQUEST_TIMEOUT = 30000;
-const CONNECTION_FILE = process.env.THUNDERBIRD_MCP_CONNECTION_FILE
-  || path.join(os.tmpdir(), 'thunderbird-mcp', 'connection.json');
+const DEFAULT_CONNECTION_FILE = path.join(os.tmpdir(), 'thunderbird-mcp', 'connection.json');
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_MAX_RETRIES = 5;
+
+function resolveConnectionFile() {
+  const envFile = process.env.THUNDERBIRD_MCP_CONNECTION_FILE;
+  if (envFile) {
+    return envFile;
+  }
+
+  const runtimeDir = process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid()}`;
+  const flatpakPath = path.join(
+    runtimeDir,
+    'app',
+    'org.mozilla.Thunderbird',
+    'thunderbird-mcp',
+    'connection.json'
+  );
+  if (fs.existsSync(flatpakPath)) {
+    return flatpakPath;
+  }
+
+  if (fs.existsSync(DEFAULT_CONNECTION_FILE)) {
+    return DEFAULT_CONNECTION_FILE;
+  }
+
+  return DEFAULT_CONNECTION_FILE;
+}
+
+const CONNECTION_FILE = resolveConnectionFile();
 
 /**
  * Read connection info (port + auth token) written by the Thunderbird extension.

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -14,7 +14,8 @@ const os = require('os');
 
 const THUNDERBIRD_HOSTS = ['127.0.0.1'];
 const REQUEST_TIMEOUT = 30000;
-const CONNECTION_FILE = path.join(os.tmpdir(), 'thunderbird-mcp', 'connection.json');
+const CONNECTION_FILE = process.env.THUNDERBIRD_MCP_CONNECTION_FILE
+  || path.join(os.tmpdir(), 'thunderbird-mcp', 'connection.json');
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_MAX_RETRIES = 5;
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,9 +10,16 @@ XPI_FILE="$DIST_DIR/thunderbird-mcp.xpi"
 
 # Find Thunderbird profile directory
 find_profile() {
-    local profiles_dir="$HOME/.thunderbird"
-    if [[ ! -d "$profiles_dir" ]]; then
-        echo "Error: Thunderbird profiles directory not found at $profiles_dir" >&2
+    local flatpak_profiles_dir="$HOME/.var/app/org.mozilla.Thunderbird/.thunderbird"
+    local standard_profiles_dir="$HOME/.thunderbird"
+    local profiles_dir
+
+    if [[ -d "$flatpak_profiles_dir" ]]; then
+        profiles_dir="$flatpak_profiles_dir"
+    elif [[ -d "$standard_profiles_dir" ]]; then
+        profiles_dir="$standard_profiles_dir"
+    else
+        echo "Error: Thunderbird profiles directory not found (checked $flatpak_profiles_dir and $standard_profiles_dir)" >&2
         exit 1
     fi
 
@@ -23,7 +30,7 @@ find_profile() {
     fi
 
     if [[ -z "$profile" ]]; then
-        echo "Error: No Thunderbird profile found" >&2
+        echo "Error: No Thunderbird profile found in $profiles_dir" >&2
         exit 1
     fi
 


### PR DESCRIPTION
Fixes TKasperczyk/thunderbird-mcp#61

## Changes

- **mcp-bridge.cjs**: Added `resolveConnectionFile()` that tries in order: `THUNDERBIRD_MCP_CONNECTION_FILE` env var, Flatpak XDG runtime path, original `/tmp` fallback
- **scripts/install.sh**: `find_profile()` now checks `~/.var/app/org.mozilla.Thunderbird/.thunderbird/` before `~/.thunderbird/`
- **README.md**: Added Flatpak Installation section with auto-detection explanation, env var override docs, and config snippets for Claude Code and Codex

## Testing

`npm test` — repository has no test script. Manual verification: bridge connects successfully on Fedora with Flatpak Thunderbird.

---

*AI attribution: [AI-C](https://1angdon.com/ai-attribution) — human and AI iterated together; human directed, reviewed, and takes responsibility.*
