### PR TITLE
fix: use ~/.thunderbird-mcp for connection file instead of os.tmpdir()

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -842,11 +842,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             /**
              * Write connection info (port + auth token) to a well-known file
              * so the bridge can discover how to connect.
-             * File: <TmpD>/thunderbird-mcp/connection.json
+             * File: <Home>/.thunderbird-mcp/connection.json
              */
             function writeConnectionInfo(port, token) {
-              const tmpDir = Services.dirsvc.get("TmpD", Ci.nsIFile);
-              tmpDir.append("thunderbird-mcp");
+              const tmpDir = Services.dirsvc.get("Home", Ci.nsIFile);
+              tmpDir.append(".thunderbird-mcp");
               if (!tmpDir.exists()) {
                 tmpDir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
               }
@@ -876,8 +876,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
              */
             function removeConnectionInfo() {
               try {
-                const tmpDir = Services.dirsvc.get("TmpD", Ci.nsIFile);
-                tmpDir.append("thunderbird-mcp");
+                const tmpDir = Services.dirsvc.get("Home", Ci.nsIFile);
+                tmpDir.append(".thunderbird-mcp");
                 const connFile = tmpDir.clone();
                 connFile.append("connection.json");
                 if (connFile.exists()) {
@@ -4885,10 +4885,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             buildDate = bi.builtAt || null;
           } catch { /* build info not available */ }
 
-          // Read connection info from temp file using XPCOM file I/O
+          // Read connection info from home dir using XPCOM file I/O
           try {
-            const tmpDir = Services.dirsvc.get("TmpD", Ci.nsIFile);
-            tmpDir.append("thunderbird-mcp");
+            const tmpDir = Services.dirsvc.get("Home", Ci.nsIFile);
+            tmpDir.append(".thunderbird-mcp");
             const connFile = tmpDir.clone();
             connFile.append("connection.json");
             connectionFile = connFile.path;
@@ -5061,8 +5061,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
     // Always clean up the connection info file so stale tokens don't linger
     // (Inlined here because removeConnectionInfo() is scoped inside start())
     try {
-      const tmpDir = Services.dirsvc.get("TmpD", Ci.nsIFile);
-      tmpDir.append("thunderbird-mcp");
+      const tmpDir = Services.dirsvc.get("Home", Ci.nsIFile);
+      tmpDir.append(".thunderbird-mcp");
       const connFile = tmpDir.clone();
       connFile.append("connection.json");
       if (connFile.exists()) {

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -14,7 +14,7 @@ const os = require('os');
 
 const THUNDERBIRD_HOSTS = ['127.0.0.1'];
 const REQUEST_TIMEOUT = 30000;
-const CONNECTION_FILE = path.join(os.tmpdir(), 'thunderbird-mcp', 'connection.json');
+const CONNECTION_FILE = path.join(os.homedir(), '.thunderbird-mcp', 'connection.json');
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_MAX_RETRIES = 5;
 
@@ -188,8 +188,9 @@ async function forwardToThunderbird(message, _retried) {
     }
     if (!connInfo) {
       throw new Error(
-        'Connection file not found. Is Thunderbird running with the MCP extension? ' +
-        'The extension must be started first to create the connection file.'
+        `Bridge error: Connection file not found at ${CONNECTION_FILE}. ` +
+        `Is Thunderbird running with the MCP extension? ` +
+        `TMPDIR=${process.env.TMPDIR || '(not set)'}, os.tmpdir()=${os.tmpdir()}`
       );
     }
   }


### PR DESCRIPTION
- Connection file path changed from `os.tmpdir()/thunderbird-mcp/` to `os.homedir()/.thunderbird-mcp/` in bridge and `Home/.thunderbird-mcp` in extension
- Fixes path mismatch when Claude.ai spawns the bridge without `TMPDIR` env var (`os.tmpdir()` returns `/tmp`, but Thunderbird's `TmpD` resolves to `/var/folders/.../T/`)
- Error message now includes actual path and env diagnostics