### PR TITLE
fix: update extension ID in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ echo "Installing to profile: $PROFILE_DIR"
 mkdir -p "$EXTENSIONS_DIR"
 
 # Copy extension
-cp "$XPI_FILE" "$EXTENSIONS_DIR/thunderbird-mcp@luthriel.dev.xpi"
+cp "$XPI_FILE" "$EXTENSIONS_DIR/thunderbird-mcp@tkasperczyk.dev.xpi"
 
 echo "Installed! Restart Thunderbird to activate."
 echo ""


### PR DESCRIPTION
`install.sh` still used the old extension ID (`thunderbird-mcp@luthriel.dev`) after it was changed to `thunderbird-mcp@tkasperczyk.dev` in 8d2d397, causing silent installation failure — the XPI is copied with the wrong filename so Thunderbird doesn't recognize it.
