### PR TITLE
fix(search): AND-of-tokens matching with field-operator support

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1996,6 +1996,22 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 	              const results = [];
 	              const lowerQuery = (query || "").toLowerCase();
 	              const hasQuery = !!lowerQuery;
+	              // Parse optional field-operator prefix and split into AND tokens.
+	              // Supports: from:Name, subject:Text, to:Email, cc:Email
+	              // Without an operator, every token must appear somewhere across all fields.
+	              const _OPERATOR_RE = /^(from|subject|to|cc):\s*/;
+	              let fieldTarget = null;
+	              let queryTokens = [];
+	              if (hasQuery) {
+	                const opMatch = lowerQuery.match(_OPERATOR_RE);
+	                if (opMatch) {
+	                  const opMap = { from: 'author', subject: 'subject', to: 'recipients', cc: 'ccList' };
+	                  fieldTarget = opMap[opMatch[1]];
+	                  queryTokens = lowerQuery.slice(opMatch[0].length).trim().split(/\s+/).filter(Boolean);
+	                } else {
+	                  queryTokens = lowerQuery.split(/\s+/).filter(Boolean);
+	                }
+	              }
 	              const parsedStartDate = startDate ? new Date(startDate).getTime() : NaN;
               const parsedEndDate = endDate ? new Date(endDate).getTime() : NaN;
               const startDateTs = Number.isFinite(parsedStartDate) ? parsedStartDate * 1000 : null;
@@ -2052,12 +2068,20 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       const author = (msgHdr.mime2DecodedAuthor || msgHdr.author || "").toLowerCase();
                       const recipients = (msgHdr.mime2DecodedRecipients || msgHdr.recipients || "").toLowerCase();
                       const ccList = (msgHdr.ccList || "").toLowerCase();
-                      // Search headers first, then body preview (first ~200 chars stored in DB)
-                      if (!subject.includes(lowerQuery) &&
-                          !author.includes(lowerQuery) &&
-                          !recipients.includes(lowerQuery) &&
-                          !ccList.includes(lowerQuery) &&
-                          !preview.toLowerCase().includes(lowerQuery)) continue;
+                      // AND-of-tokens: every token must appear somewhere across the fields.
+                      // If a field operator (from:, subject:, to:, cc:) was given,
+                      // restrict matching to that specific field only.
+                      const _fieldValues = { subject, author, recipients, ccList };
+                      const _matches = fieldTarget
+                        ? queryTokens.every(t => (_fieldValues[fieldTarget] || "").includes(t))
+                        : queryTokens.every(t =>
+                            subject.includes(t) ||
+                            author.includes(t) ||
+                            recipients.includes(t) ||
+                            ccList.includes(t) ||
+                            preview.toLowerCase().includes(t)
+                          );
+                      if (!_matches) continue;
                     }
 
                     const msgTags = getUserTags(msgHdr);


### PR DESCRIPTION
## Problem

`searchMessages` treats the entire `query` string as a single contiguous substring, which causes two classes of failure:

1. **Multi-word non-contiguous queries return nothing.** A query like `Inquiry Behavioral Science` fails if the words do not appear adjacent in any single field — even though each word individually would match.

2. **Field-operator syntax (`from:`, `subject:`) is silently ignored.** The colon is treated as a literal character, so `from:Alpha Beta Gamma` searches for the string `"from:alpha beta gamma"` verbatim — which never matches.

## Fix

Two changes to `searchMessages` in `extension/mcp_server/api.js`:

**1. AND-of-tokens** — split the query on whitespace; require every token to appear somewhere across subject/author/recipients/CC/preview (OR per field, AND across tokens). This makes multi-word queries work without requiring exact adjacency.

**2. Field-operator prefix parsing** — if the query starts with `from:`, `subject:`, `to:`, or `cc:`, strip the prefix and restrict all tokens to that specific field only. Examples:
- `from:Alpha Beta Gamma` → all tokens must appear in the author field
- `subject:Delta Epsilon` → all tokens must appear in the subject
- `Zeta Eta Theta` → each token must appear somewhere across all fields

## Behaviour preserved

- Single-token queries work identically to before
- Exact-phrase matches still work (each word is a token, all must be present)
- `unreadOnly`, `flaggedOnly`, `tag`, date range, and `searchBody` are unaffected

## Testing

Verified against a live Thunderbird account with the following queries (all previously failing, now returning correct results):

| Query | Result |
|---|---|
| `from:Alpha Beta Gamma` | ✅ found by author |
| `Inquiry Regarding Research Opportunities Behavioral` | ✅ found by AND-of-tokens |
| `subject:Delta Epsilon Zeta` | ✅ found by subject field |
| Single token / email address / exact phrase | ✅ no regression |