### PR TITLE
feat(calendar): add updateTask tool

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -270,6 +270,26 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
       },
       {
+        name: "updateTask",
+        group: "calendar", crud: "update",
+        title: "Update Task",
+        description: "Update an existing task/to-do: change title, due date, description, priority, completion status, or percent complete",
+        inputSchema: {
+          type: "object",
+          properties: {
+            taskId: { type: "string", description: "Task ID (from listTasks results)" },
+            calendarId: { type: "string", description: "Calendar ID containing the task (from listTasks results)" },
+            title: { type: "string", description: "New task title (optional)" },
+            dueDate: { type: "string", description: "New due date in ISO 8601 format (optional)" },
+            description: { type: "string", description: "New task description/body (optional)" },
+            completed: { type: "boolean", description: "Set to true to mark the task done (sets percentComplete=100 and records completedDate), false to reopen it (optional)" },
+            percentComplete: { type: "integer", description: "Completion percentage 0–100 (optional)" },
+            priority: { type: "integer", description: "Priority: 1=high, 5=normal, 9=low (optional)" },
+          },
+          required: ["taskId", "calendarId"],
+        },
+      },
+      {
         name: "searchContacts",
         group: "contacts", crud: "read",
         title: "Search Contacts",
@@ -2495,6 +2515,85 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               };
             }
 
+            async function updateTask(taskId, calendarId, title, dueDate, description, completed, percentComplete, priority) {
+              if (!cal) return { error: "Calendar not available" };
+              try {
+                if (!taskId) return { error: "taskId is required" };
+                if (!calendarId) return { error: "calendarId is required" };
+
+                const calendar = cal.manager.getCalendars().find(c => c.id === calendarId);
+                if (!calendar) return { error: `Calendar not found: ${calendarId}` };
+                if (calendar.readOnly) return { error: `Calendar is read-only: ${calendar.name}` };
+
+                // Try direct lookup first, then fall back to scanning all tasks
+                let oldItem = null;
+                if (typeof calendar.getItem === "function") {
+                  try { oldItem = await calendar.getItem(taskId); } catch {}
+                }
+                if (!oldItem) {
+                  const FILTER_TODO = 1 << 2;
+                  const COMPLETED_YES = 1 << 0;
+                  const COMPLETED_NO = 1 << 1;
+                  let items;
+                  if (typeof calendar.getItemsAsArray === "function") {
+                    items = await calendar.getItemsAsArray(FILTER_TODO | COMPLETED_YES | COMPLETED_NO, 0, null, null);
+                  } else {
+                    items = [];
+                    const stream = cal.iterate.streamValues(calendar.getItems(FILTER_TODO | COMPLETED_YES | COMPLETED_NO, 0, null, null));
+                    for await (const chunk of stream) {
+                      for (const i of chunk) items.push(i);
+                    }
+                  }
+                  oldItem = items.find(i => i.id === taskId) || null;
+                }
+                if (!oldItem) return { error: `Task not found: ${taskId}` };
+
+                const newItem = oldItem.clone();
+                const changes = [];
+
+                if (title !== undefined) { newItem.title = title; changes.push("title"); }
+                if (description !== undefined) { newItem.setProperty("DESCRIPTION", description); changes.push("description"); }
+                if (priority !== undefined) { newItem.priority = priority; changes.push("priority"); }
+
+                if (dueDate !== undefined) {
+                  const js = new Date(dueDate);
+                  if (isNaN(js.getTime())) return { error: `Invalid dueDate: ${dueDate}` };
+                  if (/^\d{4}-\d{2}-\d{2}$/.test(dueDate.trim())) {
+                    const dt = cal.createDateTime();
+                    dt.resetTo(js.getFullYear(), js.getMonth(), js.getDate(), 0, 0, 0, cal.dtz.floating);
+                    dt.isDate = true;
+                    newItem.dueDate = dt;
+                  } else {
+                    newItem.dueDate = cal.dtz.jsDateToDateTime(js, cal.dtz.defaultTimezone);
+                  }
+                  changes.push("dueDate");
+                }
+
+                if (percentComplete !== undefined) {
+                  newItem.percentComplete = Math.min(100, Math.max(0, percentComplete));
+                  changes.push("percentComplete");
+                }
+
+                if (completed !== undefined) {
+                  if (completed) {
+                    newItem.percentComplete = 100;
+                    newItem.completedDate = cal.dtz.jsDateToDateTime(new Date(), cal.dtz.defaultTimezone);
+                  } else {
+                    newItem.percentComplete = 0;
+                    newItem.completedDate = null;
+                  }
+                  changes.push("completed");
+                }
+
+                if (changes.length === 0) return { error: "No changes specified" };
+
+                await calendar.modifyItem(newItem, oldItem);
+                return { success: true, updated: changes, task: formatTask(newItem, calendar) };
+              } catch (e) {
+                return { error: e.toString() };
+              }
+            }
+
             async function listEvents(calendarId, startDate, endDate, maxResults) {
               if (!cal) {
                 return { error: "Calendar not available" };
@@ -4628,6 +4727,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return createTask(args.title, args.dueDate, args.calendarId);
                 case "listTasks":
                   return await listTasks(args.calendarId, args.completed, args.dueBefore, args.maxResults);
+                case "updateTask":
+                  return await updateTask(args.taskId, args.calendarId, args.title, args.dueDate, args.description, args.completed, args.percentComplete, args.priority);
                 case "sendMail":
                   return await composeMail(args.to, args.subject, args.body, args.cc, args.bcc, args.isHtml, args.from, args.attachments, args.skipReview);
                 case "replyToMessage":


### PR DESCRIPTION
## Summary

Adds a new `updateTask` MCP tool to update existing tasks/to-dos in Thunderbird calendars.

**Supported fields:**
- `taskId` *(required)* — task ID from `listTasks` results
- `calendarId` *(required)* — calendar ID from `listTasks` results
- `title` — new task title
- `dueDate` — new due date (ISO 8601)
- `description` — new task description/body
- `priority` — task priority
- `completed` — boolean; `true` sets `percentComplete=100` and records `completedDate`, `false` reopens the task
- `percentComplete` — numeric completion percentage

**Implementation notes:**
- Looks up the task by ID using `calendar.getItem()` with a fallback full-scan for compatibility across calendar backends
- Returns the updated task in the same format as `listTasks`
- Complements the existing `createTask` and `listTasks` tools to complete basic CRUD for calendar tasks

## Test plan

- [ ] Mark a task as completed (`completed: true`) and verify `percentComplete` becomes 100
- [ ] Reopen a completed task (`completed: false`) and verify it appears in `listTasks`
- [ ] Update `title` and `dueDate` and verify changes persist
- [ ] Confirm error is returned for unknown `taskId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)