### PR TITLE
fix: spec-compliant MCP transport + silent-failure sweep

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -4628,7 +4628,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     count += hdrs.length;
                   }
                 }
-              } catch {}
+              } catch (e) {
+                // Continue traversal; log per-folder failures so partial empties are visible.
+                console.error("thunderbird-mcp: deleteMessages failed for folder", folder?.URI || folder?.name, ":", e);
+              }
               if (folder.hasSubFolders) {
                 for (const sub of folder.subFolders) {
                   count += deleteAllMessagesRecursive(sub);
@@ -5305,7 +5308,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   try {
                     const parsed = JSON.parse(value);
                     if (Array.isArray(parsed)) args[key] = parsed;
-                  } catch { /* leave as-is for validation to catch */ }
+                  } catch (e) {
+                    // Leave value as-is so validator surfaces a typed error to the client.
+                    console.warn(`thunderbird-mcp: coerceToolArgs JSON.parse failed for key=${key}:`, e.message);
+                  }
                 }
               }
               return args;
@@ -5559,7 +5565,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   }));
                 }
                 res.finish();
-              })();
+              })().catch((e) => {
+                console.error("thunderbird-mcp: unhandled dispatch error:", e);
+                try { res.finish(); } catch {}
+              });
             });
 
             // Try the default port first, then fall back to nearby ports
@@ -5584,7 +5593,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               connFilePath = writeConnectionInfo(boundPort, authToken);
             } catch (writeErr) {
               // Connection file write failed -- stop the orphaned server
-              try { server.stop(() => {}); } catch {}
+              try { server.stop(() => {}); } catch (e) { console.error("thunderbird-mcp: server.stop failed:", e); }
               globalThis.__tbMcpServer = null;
               throw writeErr;
             }
@@ -5595,7 +5604,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             console.error("Failed to start MCP server:", e);
             // Stop server if it was started but something else failed
             if (globalThis.__tbMcpServer) {
-              try { globalThis.__tbMcpServer.stop(() => {}); } catch {}
+              try { globalThis.__tbMcpServer.stop(() => {}); } catch (e) { console.error("thunderbird-mcp: server.stop failed:", e); }
               globalThis.__tbMcpServer = null;
             }
             // Clear cached promise so a retry can attempt to bind again
@@ -5630,7 +5639,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             const bi = JSON.parse(text);
             buildVersion = bi.version || bi.commit || null;
             buildDate = bi.builtAt || null;
-          } catch { /* build info not available */ }
+          } catch (e) {
+            // buildinfo.json may legitimately be absent in dev builds; surface anything else.
+            if (e?.name !== "NS_ERROR_FILE_NOT_FOUND") {
+              console.warn("thunderbird-mcp: read buildinfo failed:", e);
+            }
+          }
 
           // Read connection info from temp file using XPCOM file I/O
           try {
@@ -5651,7 +5665,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               const data = JSON.parse(text);
               port = data.port || null;
             }
-          } catch { /* ignore */ }
+          } catch (e) {
+            // Connection file is absent before the server first binds; log other faults.
+            if (e?.name !== "NS_ERROR_FILE_NOT_FOUND") {
+              console.warn("thunderbird-mcp: read connection info failed:", e);
+            }
+          }
 
           return {
             running: !!globalThis.__tbMcpStartPromise,
@@ -5670,7 +5689,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
           try {
             const pref = Services.prefs.getStringPref(PREF_ALLOWED_ACCOUNTS, "");
             if (pref) allowed = JSON.parse(pref);
-          } catch { /* ignore */ }
+          } catch (e) {
+            // Falls back to "all accounts allowed"; surface the corruption.
+            console.warn("thunderbird-mcp: account-access pref is not valid JSON:", e.message);
+          }
 
           const accounts = [];
           for (const account of MailServices.accounts.accounts) {

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -20,6 +20,42 @@ const resProto = Cc[
 
 const MCP_DEFAULT_PORT = 8765;
 const MCP_MAX_PORT_ATTEMPTS = 10;
+
+// Versions of the MCP protocol this server understands. Behavior never depends
+// on the negotiated version inside Thunderbird (the bridge intercepts initialize
+// for clients), but for the rare case a client talks directly to the HTTP server
+// we still need a spec-compliant negotiated value. Keep in sync with mcp-bridge.cjs.
+const MCP_SUPPORTED_PROTOCOL_VERSIONS = new Set([
+  "2024-11-05",
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+]);
+const MCP_LATEST_PROTOCOL_VERSION = "2025-11-25";
+
+// Bridged into serverInfo.version on initialize. Resolved lazily from the
+// extension manifest so a single bump in extension/manifest.json propagates here.
+let _cachedExtVersion = null;
+function getExtVersion() {
+  if (_cachedExtVersion) return _cachedExtVersion;
+  try {
+    const uri = Services.io.newURI("resource://thunderbird-mcp/manifest.json");
+    const channel = Services.io.newChannelFromURI(uri, null,
+      Services.scriptSecurityManager.getSystemPrincipal(), null,
+      Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL,
+      Ci.nsIContentPolicy.TYPE_OTHER);
+    const sis = Cc["@mozilla.org/scriptableinputstream;1"]
+      .createInstance(Ci.nsIScriptableInputStream);
+    sis.init(channel.open());
+    const text = sis.read(sis.available());
+    sis.close();
+    _cachedExtVersion = JSON.parse(text).version || "0.0.0";
+  } catch (e) {
+    console.warn("thunderbird-mcp: could not read extension manifest version:", e);
+    _cachedExtVersion = "0.0.0";
+  }
+  return _cachedExtVersion;
+}
 // Keep references to active attach timers to prevent GC before they fire.
 const _attachTimers = new Set();
 // Track temp files created for inline base64 attachments (cleaned up on shutdown).
@@ -1367,9 +1403,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
 
             function addAttachmentsToComposeWindow(composeWin, attachDescs) {
-              if (!composeWin || typeof composeWin.AddAttachments !== "function") return;
+              if (!composeWin) {
+                console.warn("thunderbird-mcp: skipping attachment add — no compose window");
+                return;
+              }
+              if (typeof composeWin.AddAttachments !== "function") {
+                console.warn("thunderbird-mcp: skipping attachment add — composeWin.AddAttachments not a function");
+                return;
+              }
               const attachList = descsToMsgAttachments(attachDescs);
               if (attachList.length > 0) {
+                // Caller's try/catch (or fire-and-forget caller) is responsible for
+                // surfacing failures — do not swallow here.
                 composeWin.AddAttachments(attachList);
               }
             }
@@ -1384,7 +1429,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   try {
                     const composeWin = Services.wm.getMostRecentWindow("msgcompose");
                     addAttachmentsToComposeWindow(composeWin, attachDescs);
-                  } catch {}
+                  } catch (e) {
+                    // Fire-and-forget timer — no client to error back to.
+                    // Log loudly so users can find the cause in the Error Console
+                    // when an "email sent without attachments" report comes in.
+                    console.error("thunderbird-mcp: injectAttachmentsAsync failed:", e);
+                  }
                 }
               }, COMPOSE_WINDOW_LOAD_DELAY_MS, Ci.nsITimer.TYPE_ONE_SHOT);
             }
@@ -5437,13 +5487,22 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 try {
                   let result;
                   switch (method) {
-                    case "initialize":
+                    case "initialize": {
+                      // Per MCP lifecycle: respond with the requested version if
+                      // we support it, otherwise the latest version we know.
+                      // Behavior never depends on the version inside Thunderbird,
+                      // so we accept any well-known protocol version.
+                      const requested = params?.protocolVersion;
+                      const negotiated = (typeof requested === "string" && MCP_SUPPORTED_PROTOCOL_VERSIONS.has(requested))
+                        ? requested
+                        : MCP_LATEST_PROTOCOL_VERSION;
                       result = {
-                        protocolVersion: "2024-11-05",
+                        protocolVersion: negotiated,
                         capabilities: { tools: {} },
-                        serverInfo: { name: "thunderbird-mcp", version: "0.1.0" }
+                        serverInfo: { name: "thunderbird-mcp", version: getExtVersion() }
                       };
                       break;
+                    }
                     case "resources/list":
                       result = { resources: [] };
                       break;

--- a/extension/options.js
+++ b/extension/options.js
@@ -289,7 +289,7 @@ saveSkipReviewBtn.addEventListener("click", async () => {
   saveSkipReviewBtn.disabled = false;
 });
 
-loadServerInfo();
-loadAccountAccess();
-loadToolAccess();
-loadSkipReviewPref();
+loadServerInfo().catch(e => console.error("thunderbird-mcp options:", "loadServerInfo failed:", e));
+loadAccountAccess().catch(e => console.error("thunderbird-mcp options:", "loadAccountAccess failed:", e));
+loadToolAccess().catch(e => console.error("thunderbird-mcp options:", "loadToolAccess failed:", e));
+loadSkipReviewPref().catch(e => console.error("thunderbird-mcp options:", "loadSkipReviewPref failed:", e));

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -7,7 +7,6 @@
  */
 
 const http = require('http');
-const readline = require('readline');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -22,6 +21,38 @@ const DEFAULT_PROC_ROOT = '/proc';
 const DEFAULT_DARWIN_FOLDERS_ROOT = '/var/folders';
 const THUNDERBIRD_MCP_SUBDIR = 'thunderbird-mcp';
 const CONNECTION_FILE_BASENAME = 'connection.json';
+
+// MCP protocol versions the bridge knows how to speak. Per lifecycle spec the
+// server MUST respond with the requested version if it supports it, otherwise
+// with the latest version it supports. The bridge is a transparent JSON-RPC
+// relay -- behavior never changes by version -- so it accepts every published
+// version, but it does NOT echo unknown future versions back as if it knew them.
+const SUPPORTED_PROTOCOL_VERSIONS = new Set([
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25',
+]);
+const LATEST_PROTOCOL_VERSION = '2025-11-25';
+const BRIDGE_VERSION = (() => {
+  try {
+    return require('./package.json').version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+const SERVER_INFO = Object.freeze({
+  name: 'thunderbird-mcp',
+  version: BRIDGE_VERSION,
+});
+
+const DEBUG = !!process.env.THUNDERBIRD_MCP_DEBUG;
+
+function debugLog(message) {
+  if (DEBUG) {
+    process.stderr.write('[thunderbird-mcp] ' + message + '\n');
+  }
+}
 
 let cachedConnectionInfo = null;
 let connectionCacheExpiry = 0;
@@ -523,20 +554,21 @@ async function handleMessage(line) {
   // Handle MCP lifecycle methods locally so the bridge can complete
   // handshake even when Thunderbird isn't running yet.
   switch (message.method) {
-    case 'initialize':
+    case 'initialize': {
+      const requested = message.params?.protocolVersion;
+      const negotiated = (typeof requested === 'string' && SUPPORTED_PROTOCOL_VERSIONS.has(requested))
+        ? requested
+        : LATEST_PROTOCOL_VERSION;
       return {
         jsonrpc: '2.0',
         id: message.id,
         result: {
-          // Echo whatever the client requested — the bridge is a transparent
-          // relay and supports any JSON-RPC version Thunderbird's API speaks.
-          // Claude Desktop disconnects silently when negotiated to an older
-          // version, so always agree.
-          protocolVersion: message.params?.protocolVersion || '2024-11-05',
+          protocolVersion: negotiated,
           capabilities: { tools: {} },
-          serverInfo: { name: 'thunderbird-mcp', version: '0.1.0' }
-        }
+          serverInfo: SERVER_INFO,
+        },
       };
+    }
     case 'ping':
       return { jsonrpc: '2.0', id: message.id, result: {} };
     case 'resources/list':
@@ -659,16 +691,14 @@ async function forwardToThunderbird(message, _retried) {
 }
 
 function startBridge() {
-  // Ensure stdout doesn't buffer - critical for MCP protocol
-  if (process.stdout._handle?.setBlocking) {
-    process.stdout._handle.setBlocking(true);
-  }
-
   let pendingRequests = 0;
   let stdinClosed = false;
 
+  debugLog(`startup version=${BRIDGE_VERSION} pid=${process.pid} platform=${process.platform}`);
+
   function checkExit() {
     if (stdinClosed && pendingRequests === 0) {
+      debugLog('shutdown stdin-closed and no pending requests, exiting 0');
       process.exit(0);
     }
   }
@@ -683,29 +713,33 @@ function startBridge() {
     });
   }
 
-  // Process stdin as JSON-RPC messages
-  const rl = readline.createInterface({ input: process.stdin, terminal: false });
-
-  rl.on('line', (line) => {
+  function dispatch(line) {
     if (!line.trim()) {
       return;
     }
 
     let messageId = null;
+    let messageMethod = null;
     try {
-      messageId = JSON.parse(line).id ?? null;
+      const parsed = JSON.parse(line);
+      messageId = parsed.id ?? null;
+      messageMethod = parsed.method ?? null;
     } catch {
       // Leave as null when request cannot be parsed
     }
+
+    debugLog(`recv method=${messageMethod} id=${messageId}`);
 
     pendingRequests++;
     handleMessage(line)
       .then(async (response) => {
         if (response !== null) {
           await writeOutput(JSON.stringify(response) + '\n');
+          debugLog(`send id=${messageId} method=${messageMethod}`);
         }
       })
       .catch(async (err) => {
+        debugLog(`error id=${messageId} method=${messageMethod} message=${err.message}`);
         await writeOutput(JSON.stringify({
           jsonrpc: '2.0',
           id: messageId,
@@ -716,9 +750,31 @@ function startBridge() {
         pendingRequests--;
         checkExit();
       });
-  });
+  }
 
-  rl.on('close', () => {
+  // Manual newline-delimited JSON parsing on raw stdin. The previous
+  // readline-based implementation lost the initialize response under
+  // Claude Desktop's Electron-spawned Node on Windows -- writes from
+  // promise callbacks never made it back through the pipe. Reading raw
+  // 'data' events with explicit utf8 encoding matches what the official
+  // @modelcontextprotocol/sdk stdio transport does and works reliably.
+  process.stdin.setEncoding('utf8');
+  let buffer = '';
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    let idx;
+    while ((idx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, idx).replace(/\r$/, '');
+      buffer = buffer.slice(idx + 1);
+      dispatch(line);
+    }
+  });
+  process.stdin.on('end', () => {
+    if (buffer.length > 0) {
+      const tail = buffer.replace(/\r$/, '');
+      buffer = '';
+      dispatch(tail);
+    }
     stdinClosed = true;
     checkExit();
   });

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -528,7 +528,11 @@ async function handleMessage(line) {
         jsonrpc: '2.0',
         id: message.id,
         result: {
-          protocolVersion: '2024-11-05',
+          // Echo whatever the client requested — the bridge is a transparent
+          // relay and supports any JSON-RPC version Thunderbird's API speaks.
+          // Claude Desktop disconnects silently when negotiated to an older
+          // version, so always agree.
+          protocolVersion: message.params?.protocolVersion || '2024-11-05',
           capabilities: { tools: {} },
           serverInfo: { name: 'thunderbird-mcp', version: '0.1.0' }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunderbird-mcp",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "MCP server for Thunderbird - enables AI assistants to access email, contacts, and calendars",
   "author": "Tomasz Kasperczyk",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Two related changes that surfaced from debugging an *Unable to connect to extension server* error in Claude Desktop ≥ 1.1.380:

1. **Bridge transport rewrite** so initialize responses actually reach modern Claude Desktop (`mcp-bridge.cjs`).
2. **Silent-failure sweep** across the extension and the bridge so the next mystery doesn't take an afternoon (`extension/mcp_server/api.js`, `extension/options.js`).

## Bridge changes (`mcp-bridge.cjs`)

- **Replace readline-based stdin loop with explicit utf-8 buffered `data` handler.** Under Claude Desktop's Electron-spawned Node on Windows the readline-based loop swallowed the initialize response — writes from promise callbacks never made it back through the pipe. The new loop matches what `@modelcontextprotocol/sdk` does and works reliably. Drops the private `process.stdout._handle.setBlocking()` call.
- **Spec-compliant initialize per MCP 2025-06-18 lifecycle.** Respond with the requested `protocolVersion` if known, else the latest version we support. `SUPPORTED_PROTOCOL_VERSIONS` keeps unknown future versions from being echoed blindly.
- **`serverInfo.version` from `package.json`** so a single bump propagates.
- **Gated stderr diagnostics** (`THUNDERBIRD_MCP_DEBUG=1`) for transport events. Spec allows it; clients are free to ignore.
- **`package.json` bumped to 0.5.0** to match the extension manifest.

## Extension changes (`extension/mcp_server/api.js`, `extension/options.js`)

Same spec-compliant initialize negotiation in the HTTP handler so callers that bypass the bridge get a current version. `serverInfo.version` resolves from `extension/manifest.json` lazily.

Silent-failure fixes (audited via a separate triage):

- `addAttachmentsToComposeWindow` no longer silently no-ops when the compose window is missing or `AddAttachments` is not a function — both branches log a warning. *Reports of \"email sent without attachments\" are now traceable.*
- `injectAttachmentsAsync` fire-and-forget timer logs caught exceptions instead of swallowing.
- Tool-dispatch IIFE in the HTTP handler has a top-level `.catch` so an unhandled rejection in the inner catch (or in `res.finish`) doesn't hang the connection.
- Both `server.stop` cleanup paths during `start()` failure now log instead of `catch {}`.
- `coerceToolArgs` array-parse failure warns with key + parse error.
- `getServerInfo` build-info / connection-info reads warn on unexpected errors (file-not-found stays quiet).
- `getAccountAccessConfig` warns on a corrupt `PREF_ALLOWED_ACCOUNTS` pref.
- `deleteAllMessagesRecursive` logs each per-folder failure with the folder URI.
- `options.js` page-load kickoffs (`loadServerInfo`, `loadAccountAccess`, `loadToolAccess`, `loadSkipReviewPref`) chain `.catch` safety nets.

## Repro of the original 60s timeout (before the bridge rewrite)

```bash
printf '%s\n' '{\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"x\",\"version\":\"1\"}},\"jsonrpc\":\"2.0\",\"id\":0}' | node mcp-bridge.cjs
```

Claude Desktop log (`%APPDATA%\Claude\logs\mcp-server-Thunderbird MCP.log`) showed:

```
... Message from client: {\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",...}}
... Message from client: {\"method\":\"notifications/cancelled\",\"params\":{\"reason\":\"Request timed out\"}}
```

Filesystem MCP server in the same Claude Desktop install responds with `\"protocolVersion\":\"2025-06-18\"` (an older version) and Claude attaches normally — confirming version mismatch was a red herring; the real fault was that the bridge's initialize response never reached the parent process under the readline loop.

## Test plan

- [x] Existing test suite passes (263/282; 1 pre-existing Windows uid-test failure, 18 skipped because TB is running)
- [x] `node --check` clean on bridge, api.js, options.js
- [x] Local stdio repro of all bridge-handled methods (initialize known + unknown version, ping, resources/list, prompts/list, notifications/initialized, tools/list)
- [ ] Reviewer to load updated XPI in TB and confirm Claude Desktop attaches without timeout

## Notes for follow-up

A modular split of `api.js` (currently 5856 LoC) into `extension/mcp_server/lib/*.sys.mjs` is in progress on a separate branch and will land as its own PR sequence — not folded into this one to keep review tractable.