### PR TITLE
fix(listEvents): expand recurring events via two-phase query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ Thumbs.db
 # MCP config (contains local paths)
 .mcp.json
 
+# Local dev notes (agent/developer orientation, not for upstream)
+DEV_NOTES.md
+
 # Node.js
 node_modules/
 package-lock.json

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -2995,43 +2995,58 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 const rangeEnd = cal.dtz.jsDateToDateTime(endJs, cal.dtz.defaultTimezone);
                 const limit = Math.min(Math.max(maxResults || 100, 1), 500);
 
-                // Query with date range and occurrence expansion
+                // Two-phase query to correctly handle recurring events.
+                //
+                // The FILTER_OCCURRENCES flag is intended to make the storage layer
+                // expand recurring masters and return individual occurrences within the
+                // date range. In practice this does not work for offline-backed calendars
+                // (e.g. OWL/Exchange): recurring masters are stored with event_start set
+                // to their original first occurrence date, which is typically outside the
+                // queried range, so a date-range query never returns them and the manual
+                // expansion at the call site never runs.
+                //
+                // Fix — Phase 1: fetch non-recurring events and modified-occurrence
+                // exceptions within the date range (their event_start is inside the
+                // range). Phase 2: fetch ALL recurring masters without a date filter,
+                // then expand each with recurrenceInfo.getOccurrences() and keep only
+                // occurrences that fall within the queried range.
                 const FILTER_EVENT = 1 << 3;
-                const FILTER_OCCURRENCES = 1 << 4;
                 const results = [];
                 for (const calendar of targets) {
-                  let items;
+                  const EVENT_COLLECTION_CAP = limit * 10;
+
+                  // Phase 1: non-recurring events + modified-occurrence exceptions.
+                  const rangeItems = await getCalendarItems(calendar, rangeStart, rangeEnd);
+                  for (const item of rangeItems) {
+                    if (results.length >= EVENT_COLLECTION_CAP) break;
+                    if (!item.recurrenceInfo) results.push(formatEvent(item, calendar));
+                  }
+
+                  // Phase 2: all recurring masters (no date filter) → manual expansion.
+                  let allItems = [];
                   try {
-                    // Try with occurrence expansion first (works on most providers)
                     if (typeof calendar.getItemsAsArray === "function") {
-                      items = await calendar.getItemsAsArray(FILTER_EVENT | FILTER_OCCURRENCES, 0, rangeStart, rangeEnd);
+                      allItems = await calendar.getItemsAsArray(FILTER_EVENT, 0, null, null);
                     } else {
-                      items = [];
-                      const stream = cal.iterate.streamValues(calendar.getItems(FILTER_EVENT | FILTER_OCCURRENCES, 0, rangeStart, rangeEnd));
+                      const stream = cal.iterate.streamValues(calendar.getItems(FILTER_EVENT, 0, null, null));
                       for await (const chunk of stream) {
-                        for (const i of chunk) items.push(i);
+                        for (const i of chunk) allItems.push(i);
                       }
                     }
                   } catch {
-                    // Fallback: fetch without occurrence expansion, expand manually
-                    items = await getCalendarItems(calendar, rangeStart, rangeEnd);
+                    allItems = rangeItems;
                   }
 
-                  const EVENT_COLLECTION_CAP = limit * 10; // Safety cap for recurring event expansion
-                  for (const item of items) {
+                  for (const item of allItems) {
                     if (results.length >= EVENT_COLLECTION_CAP) break;
-                    // If we got base recurring events (fallback path), expand them
-                    if (item.recurrenceInfo) {
-                      try {
-                        const occurrences = item.recurrenceInfo.getOccurrences(rangeStart, rangeEnd, 0);
-                        for (const occ of occurrences) {
-                          if (results.length >= EVENT_COLLECTION_CAP) break;
-                          results.push(formatEvent(occ, calendar));
-                        }
-                      } catch {
-                        results.push(formatEvent(item, calendar));
+                    if (!item.recurrenceInfo) continue;
+                    try {
+                      const occurrences = item.recurrenceInfo.getOccurrences(rangeStart, rangeEnd, 0);
+                      for (const occ of occurrences) {
+                        if (results.length >= EVENT_COLLECTION_CAP) break;
+                        results.push(formatEvent(occ, calendar));
                       }
-                    } else {
+                    } catch {
                       results.push(formatEvent(item, calendar));
                     }
                   }


### PR DESCRIPTION
## Problem

`listEvents` returns no recurring events for offline-backed calendars
(e.g. OWL/Exchange). The root cause is that `FILTER_OCCURRENCES` does not
work for these calendars: recurring masters are stored with `event_start`
set to their original first-occurrence date, which is typically outside
the queried date range. A date-range query therefore never returns them,
and the manual `getOccurrences` expansion at the call site never runs.

## Fix

Replace the single-phase date-range query with a two-phase approach:

**Phase 1** — `getCalendarItems(calendar, rangeStart, rangeEnd)`:
fetches non-recurring events and modified-occurrence exceptions, whose
`event_start` is inside the range.

**Phase 2** — `getItemsAsArray(FILTER_EVENT, 0, null, null)` (no date
filter): fetches all items including recurring masters, skips
non-recurring ones, then calls `recurrenceInfo.getOccurrences(rangeStart,
rangeEnd, 0)` to expand each master and keep only occurrences that fall
within the queried window.

CalDAV calendars (e.g. Google Calendar) pre-expand recurring occurrences
as individual stored items, so they are captured by Phase 1 without
change.

## Performance

Benchmarked on a local machine against live calendars (5 runs each,
avg reported). Calendar Alpha is an Exchange/OWL-backed calendar
(1 191 cached events, 423 recurring masters). "All calendars" spans
9 calendars totalling ~10 500 cached events.

| Query range | Scope         | Events returned | Latency (avg) |
|-------------|---------------|-----------------|---------------|
| 1 day       | Calendar Alpha | 2              | 39 ms         |
| 1 week      | Calendar Alpha | 38             | 49 ms         |
| 1 month     | Calendar Alpha | 139            | 57 ms         |
| 1 week      | All calendars  | 53             | 125 ms        |
| 1 month     | All calendars  | 183            | 139 ms        |

**Tradeoff:** Phase 2 performs a full-calendar scan on every call —
O(total events in calendar), not O(query range). The range size therefore
has minimal impact on latency (39 ms for 1-day vs 57 ms for 1-month on
the same calendar). The cost is bounded by the local SQLite cache size
(no network round-trip); on the tested calendar the overhead is
acceptable. The Thunderbird calendar API does not expose a
"recurring masters only" filter, so a narrower fetch is not possible
without coupling to internal storage internals.

## Testing

Verified against a live Exchange/OWL-backed calendar:
- A daily recurring event ("Crimson"): 0 occurrences before → 5/5
  returned for a Mon–Fri query.
- A weekly recurring event ("Cobalt"): correctly returned on a
  manually-moved instance date.
- Full week comparison: all events visible in the Thunderbird UI were
  returned by `listEvents` with no missing or extra entries across
  Exchange/OWL, Google Calendar (gdata), and CalDAV calendar types.