### PR TITLE
fix(listEvents): correct CLASS_OCCURRENCES filter bit (1<<16, not 1<<4)

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -2995,9 +2995,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 const rangeEnd = cal.dtz.jsDateToDateTime(endJs, cal.dtz.defaultTimezone);
                 const limit = Math.min(Math.max(maxResults || 100, 1), 500);
 
-                // Query with date range and occurrence expansion
+                // Query with date range and occurrence expansion.
+                // Filter bits per calICalendar.idl: TYPE_EVENT = 1<<3,
+                // CLASS_OCCURRENCES = 1<<16 (NOT 1<<4 which is TYPE_JOURNAL).
                 const FILTER_EVENT = 1 << 3;
-                const FILTER_OCCURRENCES = 1 << 4;
+                const FILTER_OCCURRENCES = 1 << 16;
                 const results = [];
                 for (const calendar of targets) {
                   let items;
@@ -3012,23 +3014,31 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                         for (const i of chunk) items.push(i);
                       }
                     }
-                  } catch {
-                    // Fallback: fetch without occurrence expansion, expand manually
+                  } catch (e) {
+                    console.warn(`[thunderbird-mcp] listEvents: occurrence-expanded query failed for "${calendar.name}", falling back to manual expansion:`, e);
                     items = await getCalendarItems(calendar, rangeStart, rangeEnd);
                   }
 
                   const EVENT_COLLECTION_CAP = limit * 10; // Safety cap for recurring event expansion
                   for (const item of items) {
                     if (results.length >= EVENT_COLLECTION_CAP) break;
-                    // If we got base recurring events (fallback path), expand them
+                    // If we got base recurring events (fallback path, or provider
+                    // that returned masters despite FILTER_OCCURRENCES), expand them.
+                    // getOccurrences(start, end, maxCount) -- pass the collection cap
+                    // so infinite recurrences (e.g. daily standup) are bounded.
                     if (item.recurrenceInfo) {
                       try {
-                        const occurrences = item.recurrenceInfo.getOccurrences(rangeStart, rangeEnd, 0);
-                        for (const occ of occurrences) {
-                          if (results.length >= EVENT_COLLECTION_CAP) break;
-                          results.push(formatEvent(occ, calendar));
+                        const occurrences = item.recurrenceInfo.getOccurrences(rangeStart, rangeEnd, EVENT_COLLECTION_CAP);
+                        if (occurrences && occurrences.length) {
+                          for (const occ of occurrences) {
+                            if (results.length >= EVENT_COLLECTION_CAP) break;
+                            results.push(formatEvent(occ, calendar));
+                          }
+                        } else {
+                          results.push(formatEvent(item, calendar));
                         }
-                      } catch {
+                      } catch (e) {
+                        console.warn(`[thunderbird-mcp] listEvents: getOccurrences failed for "${item.title}" on "${calendar.name}":`, e);
                         results.push(formatEvent(item, calendar));
                       }
                     } else {


### PR DESCRIPTION
## Summary

`FILTER_OCCURRENCES` in `listEvents` was wired to `1<<4`, which is actually
`ITEM_FILTER_TYPE_JOURNAL` per `calICalendar.idl`. The correct
`CLASS_OCCURRENCES` bit is `1<<16`. With the wrong bit set:

- Storage/local calendars silently returned master items only (the bogus bit
  was ignored), so recurring events appeared once.
- CalDAV calendars rejected the unexpected filter combination, falling
  through to the manual-expansion catch path — which then called
  `getOccurrences(start, end, 0)` and could return empty for open-ended
  series.

End-user symptom: recurring events (daily stand-up, weekly meetings, etc.)
were missing from `listEvents` results.

## Changes

- `FILTER_OCCURRENCES`: `1 << 4` → `1 << 16` so the provider actually
  expands occurrences.
- The fallback catch logs via `console.warn` instead of swallowing
  silently, so provider-specific issues are diagnosable.
- `getOccurrences(start, end, maxCount)` now receives `EVENT_COLLECTION_CAP`
  as `maxCount` (bounds infinite recurrences like daily stand-up) and falls
  back to the master item if expansion returns empty.

## Test plan

- [x] Storage calendar with a weekly recurring event: `listEvents` returns
      one entry per occurrence in the range.
- [x] CalDAV calendar with a daily open-ended recurrence: `listEvents`
      returns up to `EVENT_COLLECTION_CAP` occurrences and does not hang.
- [x] Non-recurring events still appear once.