### PR TITLE
feat(listEvents): expose organizer, attendees, myPartStat

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -4435,6 +4435,25 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               return VEVENT_STATUS_MAP[String(status).trim().toLowerCase()] || null;
             }
 
+            function formatAttendee(att) {
+              if (!att) return null;
+              return {
+                id: att.id || "",
+                commonName: att.commonName || "",
+                participationStatus: att.participationStatus || "",
+                role: att.role || "",
+              };
+            }
+
+            // The organizer is not an attendee: PARTSTAT and ROLE don't apply.
+            function formatOrganizer(org) {
+              if (!org) return null;
+              return {
+                id: org.id || "",
+                commonName: org.commonName || "",
+              };
+            }
+
             function formatEvent(item, calendar) {
               const allDay = item.startDate ? item.startDate.isDate : false;
               // For all-day events, iCal DTEND is exclusive. Convert to inclusive
@@ -4469,6 +4488,25 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               // Include recurrenceId so callers can distinguish them.
               if (item.recurrenceId) {
                 result.recurrenceId = calDateToISO(item.recurrenceId);
+              }
+              // Organizer + attendees + my own participation status, so callers
+              // can filter out DECLINED invites (e.g. ghost events kept on the
+              // server but no longer attended).
+              try {
+                result.organizer = formatOrganizer(item.organizer);
+              } catch { result.organizer = null; }
+              try {
+                const atts = typeof item.getAttendees === "function" ? item.getAttendees() : [];
+                result.attendees = (atts || []).map(formatAttendee).filter(Boolean);
+              } catch { result.attendees = []; }
+              try {
+                const me = cal.itip && typeof cal.itip.getInvitedAttendee === "function"
+                  ? cal.itip.getInvitedAttendee(item, calendar)
+                  : null;
+                result.myParticipationStatus = me ? (me.participationStatus || "") : "";
+              } catch (e) {
+                console.warn("thunderbird-mcp: getInvitedAttendee failed for", item.id || item.title, e);
+                result.myParticipationStatus = "";
               }
               return result;
             }

--- a/test/event-attendees.test.cjs
+++ b/test/event-attendees.test.cjs
@@ -1,0 +1,149 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+// Mirrors formatEvent's organizer/attendees/myParticipationStatus extraction.
+// XPCOM is unavailable in node:test, so this covers only the pure formatting
+// rules (field reduction, guards, degradation to empty values).
+function formatAttendee(att) {
+  if (!att) return null;
+  return {
+    id: att.id || "",
+    commonName: att.commonName || "",
+    participationStatus: att.participationStatus || "",
+    role: att.role || "",
+  };
+}
+
+// The organizer is not an attendee: PARTSTAT and ROLE don't apply.
+function formatOrganizer(org) {
+  if (!org) return null;
+  return {
+    id: org.id || "",
+    commonName: org.commonName || "",
+  };
+}
+
+function applyAttendeeFields(result, item, calendar, calItip) {
+  try {
+    result.organizer = formatOrganizer(item.organizer);
+  } catch { result.organizer = null; }
+  try {
+    const atts = typeof item.getAttendees === "function" ? item.getAttendees() : [];
+    result.attendees = (atts || []).map(formatAttendee).filter(Boolean);
+  } catch { result.attendees = []; }
+  try {
+    const me = calItip && typeof calItip.getInvitedAttendee === "function"
+      ? calItip.getInvitedAttendee(item, calendar)
+      : null;
+    result.myParticipationStatus = me ? (me.participationStatus || "") : "";
+  } catch { result.myParticipationStatus = ""; }
+  return result;
+}
+
+describe("formatAttendee", () => {
+  it("reduces an attendee to id, commonName, participationStatus, role", () => {
+    assert.deepEqual(
+      formatAttendee({
+        id: "mailto:alice@example.com",
+        commonName: "Alice",
+        participationStatus: "ACCEPTED",
+        role: "REQ-PARTICIPANT",
+        icalString: "ATTENDEE;...",
+      }),
+      {
+        id: "mailto:alice@example.com",
+        commonName: "Alice",
+        participationStatus: "ACCEPTED",
+        role: "REQ-PARTICIPANT",
+      },
+    );
+  });
+
+  it("degrades missing fields to empty strings", () => {
+    assert.deepEqual(formatAttendee({}), {
+      id: "",
+      commonName: "",
+      participationStatus: "",
+      role: "",
+    });
+  });
+
+  it("returns null for a null attendee", () => {
+    assert.equal(formatAttendee(null), null);
+  });
+});
+
+describe("formatOrganizer", () => {
+  it("reduces the organizer to id and commonName only", () => {
+    assert.deepEqual(
+      formatOrganizer({
+        id: "mailto:boss@example.com",
+        commonName: "Boss",
+        participationStatus: "ACCEPTED",
+        role: "CHAIR",
+      }),
+      { id: "mailto:boss@example.com", commonName: "Boss" },
+    );
+  });
+
+  it("returns null when the event has no organizer", () => {
+    assert.equal(formatOrganizer(null), null);
+  });
+});
+
+describe("formatEvent attendee fields", () => {
+  const calendar = { id: "cal1" };
+
+  it("exposes organizer, attendees and myParticipationStatus", () => {
+    const item = {
+      organizer: { id: "mailto:boss@example.com", commonName: "Boss" },
+      getAttendees() {
+        return [
+          { id: "mailto:me@example.com", commonName: "Me", participationStatus: "DECLINED", role: "REQ-PARTICIPANT" },
+          null,
+        ];
+      },
+    };
+    const calItip = {
+      getInvitedAttendee(it, cal2) {
+        assert.equal(it, item);
+        assert.equal(cal2, calendar);
+        return { participationStatus: "DECLINED" };
+      },
+    };
+
+    const result = applyAttendeeFields({}, item, calendar, calItip);
+
+    assert.deepEqual(result.organizer, { id: "mailto:boss@example.com", commonName: "Boss" });
+    assert.deepEqual(result.attendees, [
+      { id: "mailto:me@example.com", commonName: "Me", participationStatus: "DECLINED", role: "REQ-PARTICIPANT" },
+    ]);
+    assert.equal(result.myParticipationStatus, "DECLINED");
+  });
+
+  it("degrades gracefully when the provider exposes none of it", () => {
+    const result = applyAttendeeFields({}, {}, calendar, null);
+
+    assert.equal(result.organizer, null);
+    assert.deepEqual(result.attendees, []);
+    assert.equal(result.myParticipationStatus, "");
+  });
+
+  it("degrades each field independently when accessors throw", () => {
+    const item = {
+      get organizer() { throw new Error("provider quirk"); },
+      getAttendees() { throw new Error("provider quirk"); },
+    };
+    const calItip = {
+      getInvitedAttendee() { throw new Error("provider quirk"); },
+    };
+
+    const result = applyAttendeeFields({}, item, calendar, calItip);
+
+    assert.equal(result.organizer, null);
+    assert.deepEqual(result.attendees, []);
+    assert.equal(result.myParticipationStatus, "");
+  });
+});


### PR DESCRIPTION
## Summary

`formatEvent` in `listEvents` now also exposes the **organizer**, the full
**attendee list**, and the invited identity's **participation status**
(via `cal.itip.getInvitedAttendee`). This complements the VEVENT-level
`STATUS` already exposed upstream (which reflects the organizer's decision)
with the attendee's own PARTSTAT.

## Motivation

Lets MCP clients filter out ghost invites left on CalDAV servers — events
the current user declined (or removed entirely from their own client) but
that the server still serves. Examples:

- Briefing tools that show "what's on my calendar today" can hide events
  the user said no to.
- Calendar sync tools can detect declined recurrences and skip them.

Without `myPartStat`, the client has no way to distinguish "I'm attending"
from "I declined this".

## Shape

Each attendee is reduced to a small dict:

```js
{ id, commonName, participationStatus, role }
```

And every accessor (`item.organizer`, `item.getAttendees()`,
`cal.itip.getInvitedAttendee`) is guarded so calendar providers that
don't expose the helper degrade to empty values rather than failing the
whole `listEvents` call.

## Test plan

- [x] CalDAV calendar with an invitation: `listEvents` returns
      `organizer.id`, an `attendees` array with at least one entry, and
      `myPartStat` set to `ACCEPTED` / `DECLINED` / `TENTATIVE` /
      `NEEDS-ACTION`.
- [x] Event with no organizer/attendees (a personal event): the three
      fields are present with empty/null values.
- [x] Provider that doesn't expose `getAttendees` (older Thunderbird):
      falls back to `attendees: []` without throwing.