### PR TITLE
feat(events): support per-occurrence delete and update via recurrenceId

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1283,7 +1283,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         name: "createEvent",
         group: "calendar", crud: "create",
         title: "Create Event",
-        description: "Create a calendar event through a review dialog. The skipReview safety block is on by default; direct creation is honored only when the user explicitly disables that preference.",
+        description: "Create a calendar event through a review dialog. The skipReview safety block is on by default; direct creation is honored only when the user explicitly disables that preference. Recurring events are supported via the recurrence parameter.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1298,6 +1298,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid block, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Defaults to 'busy'. Overridden per-property by explicit status parameter." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; use listCategories to get exact existing names before setting." },
             onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). After creation, OWL embeds the join URL in the event description and exposes it via listEvents (onlineMeetingURL). No-op on non-OWL backends." },
+            recurrence: { type: "string", description: "iCalendar RRULE string for recurring events (e.g. 'FREQ=WEEKLY;BYDAY=MO,TU,TH,FR' or 'RRULE:FREQ=DAILY;COUNT=10'). The 'RRULE:' prefix is optional and added automatically if missing. FREQ=SECONDLY and FREQ=MINUTELY are rejected." },
             skipReview: { type: "boolean", description: "Request direct creation without a review dialog. Honored only when the user explicitly disables the default-on skipReview safety block (default: false)." },
           },
           required: ["title", "startDate"],
@@ -1323,7 +1324,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         name: "updateEvent",
         group: "calendar", crud: "update",
         title: "Update Event",
-        description: "Update an existing calendar event's title, dates, location, or description",
+        description: "Update an existing calendar event's title, dates, location, description, or recurrence rule.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1338,6 +1339,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Pass null to clear TRANSP only. Explicit status parameter overrides the STATUS coupling." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; pass an empty array to clear all categories. Use listCategories to get exact existing names before setting." },
             onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). Pass false to remove an existing Teams link." },
+            recurrence: { type: "string", description: "New iCalendar RRULE string (optional). Pass an empty string (or null) to clear the recurrence and turn the event into a one-shot. The 'RRULE:' prefix is optional. FREQ=SECONDLY and FREQ=MINUTELY are rejected. Replacing the rule discards existing per-occurrence exceptions (EXDATEs / modified occurrences)." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -4249,7 +4251,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs, categories, onlineMeeting) {
+            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs, categories, onlineMeeting, recurrence) {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
@@ -4355,6 +4357,14 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 if (categories && categories.length > 0) event.setCategories(categories);
                 if (onlineMeeting) event.setProperty("X-ONLINE-MEETING-PROVIDER", "TeamsForBusiness");
 
+                if (recurrence) {
+                  try {
+                    setRecurrenceOnItem(event, recurrence);
+                  } catch (re) {
+                    return { error: `Invalid recurrence rule: ${re.toString()}` };
+                  }
+                }
+
                 // Find target calendar
                 const calendars = cal.manager.getCalendars();
                 let targetCalendar = null;
@@ -4435,6 +4445,73 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               return VEVENT_STATUS_MAP[String(status).trim().toLowerCase()] || null;
             }
 
+            // Normalize a user-supplied RRULE string: trim, accept an optional
+            // case-insensitive "RRULE:" prefix, require a FREQ part (RFC 5545
+            // makes it mandatory; without it libical fails opaquely or yields a
+            // never-firing rule), and reject FREQ=SECONDLY / FREQ=MINUTELY
+            // upfront -- Thunderbird's rrule engine parses them but generates
+            // no occurrences, so accepting them would silently create a
+            // never-firing recurrence. Returns the full "RRULE:..." line.
+            // Throws on empty or unsupported rules.
+            function normalizeRRule(recurrence) {
+              const body = String(recurrence).trim().replace(/^rrule:/i, "").trim();
+              if (!body) throw new Error("Empty recurrence rule");
+              const m = /(?:^|;)FREQ=([^;]*)/i.exec(body);
+              if (!m) throw new Error("Recurrence rule must contain a FREQ part (e.g. FREQ=WEEKLY)");
+              const freq = m[1].toUpperCase();
+              if (freq === "SECONDLY" || freq === "MINUTELY") {
+                throw new Error(`FREQ=${freq} is not supported: Thunderbird's recurrence engine generates no occurrences for it`);
+              }
+              return "RRULE:" + body;
+            }
+
+            // Build a calIRecurrenceInfo from an iCal RRULE string and attach it
+            // to `item`. Passing "" or null clears any existing recurrence. The
+            // "RRULE:" prefix is optional. Throws on invalid rules. Note: this
+            // replaces the whole calIRecurrenceInfo, so any existing EXDATEs or
+            // modified occurrences (exceptions) on the item are discarded.
+            function setRecurrenceOnItem(item, recurrence) {
+              if (recurrence === "" || recurrence === null) {
+                item.recurrenceInfo = null;
+                return;
+              }
+              const line = normalizeRRule(recurrence);
+              const fm = /(?:^|[:;])FREQ=([^;]*)/i.exec(line);
+              if (item.startDate && item.startDate.isDate && fm && fm[1].toUpperCase() === "HOURLY") {
+                throw new Error("FREQ=HOURLY cannot be applied to an all-day event: a date-only start cannot expand a sub-daily frequency");
+              }
+              const rinfo = Cc["@mozilla.org/calendar/recurrence-info;1"]
+                .createInstance(Ci.calIRecurrenceInfo);
+              rinfo.item = item;
+              const ritem = Cc["@mozilla.org/calendar/recurrence-rule;1"]
+                .createInstance(Ci.calIRecurrenceRule);
+              ritem.icalString = line;
+              rinfo.appendRecurrenceItem(ritem);
+              item.recurrenceInfo = rinfo;
+            }
+
+            // Return the first RRULE on `item` without its "RRULE:" prefix, or
+            // null if the event is not recurring / has no RRULE among its items
+            // (e.g. RDATE-only recurrences). Occurrence proxies produced by the
+            // listEvents recurrence expansion carry the rule on their
+            // parentItem, not on themselves.
+            function extractRRuleFromItem(item) {
+              const rinfo = (item.parentItem || item).recurrenceInfo;
+              if (!rinfo) return null;
+              try {
+                const rules = rinfo.getRecurrenceItems();
+                for (const r of rules) {
+                  if (r && typeof r.icalString === "string") {
+                    const line = r.icalString.replace(/\r?\n$/, "");
+                    if (line.startsWith("RRULE:")) return line.slice("RRULE:".length);
+                  }
+                }
+              } catch (e) {
+                console.warn("thunderbird-mcp: RRULE extraction failed for", item.id || item.title, e);
+              }
+              return null;
+            }
+
             function formatEvent(item, calendar) {
               const allDay = item.startDate ? item.startDate.isDate : false;
               // For all-day events, iCal DTEND is exclusive. Convert to inclusive
@@ -4463,7 +4540,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 categories: item.getCategories(),
                 onlineMeetingURL: item.getProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL") || null,
                 allDay,
-                isRecurring: !!item.recurrenceInfo,
+                isRecurring: !!(item.parentItem || item).recurrenceInfo,
+                recurrence: extractRRuleFromItem(item),
               };
               // Occurrences of recurring events share the parent's id.
               // Include recurrenceId so callers can distinguish them.
@@ -4793,7 +4871,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories, onlineMeeting) {
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories, onlineMeeting, recurrence) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -4896,6 +4974,15 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   changes.push("onlineMeeting");
                 }
 
+                if (recurrence !== undefined) {
+                  try {
+                    setRecurrenceOnItem(newItem, recurrence);
+                    changes.push("recurrence");
+                  } catch (re) {
+                    return { error: `Invalid recurrence rule: ${re.toString()}` };
+                  }
+                }
+
                 if (changes.length === 0) return { error: "No changes specified" };
 
                 // Validate end > start after all changes
@@ -4905,7 +4992,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 
                 await calendar.modifyItem(newItem, oldItem);
                 const result = { success: true, updated: changes };
-                if (oldItem.recurrenceInfo) {
+                // Read the post-update state: after clearing the recurrence
+                // (recurrence: "" / null) the event is no longer a series and
+                // the warning would state the opposite of what happened.
+                if (newItem.recurrenceInfo) {
                   result.warning = "This is a recurring event -- changes apply to the entire series.";
                 }
                 return result;
@@ -8255,11 +8345,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listCalendars":
                   return listCalendars();
                 case "createEvent":
-                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs, args.categories, args.onlineMeeting);
+                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs, args.categories, args.onlineMeeting, args.recurrence);
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories, args.onlineMeeting);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories, args.onlineMeeting, args.recurrence);
                 case "deleteEvent":
                   return await deleteEvent(args.eventId, args.calendarId);
                 case "listCategories":

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1339,7 +1339,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Pass null to clear TRANSP only. Explicit status parameter overrides the STATUS coupling." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; pass an empty array to clear all categories. Use listCategories to get exact existing names before setting." },
             onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). Pass false to remove an existing Teams link." },
-            recurrence: { type: "string", description: "New iCalendar RRULE string (optional). Pass an empty string (or null) to clear the recurrence and turn the event into a one-shot. The 'RRULE:' prefix is optional. FREQ=SECONDLY and FREQ=MINUTELY are rejected. Replacing the rule discards existing per-occurrence exceptions (EXDATEs / modified occurrences)." },
+            recurrence: { type: "string", description: "New iCalendar RRULE string (optional). Pass an empty string (or null) to clear the recurrence and turn the event into a one-shot. The 'RRULE:' prefix is optional. FREQ=SECONDLY and FREQ=MINUTELY are rejected. Replacing the rule discards existing per-occurrence exceptions (EXDATEs / modified occurrences). Cannot be combined with recurrenceId — recurrence rules apply to the master event, not a single occurrence." },
+            recurrenceId: { type: "string", description: "Optional ISO 8601 recurrence ID (from listEvents). When provided, only the matching single occurrence is modified (createException) instead of the full series. The 'recurrence' parameter must NOT be used together with recurrenceId." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -1348,12 +1349,13 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         name: "deleteEvent",
         group: "calendar", crud: "delete",
         title: "Delete Event",
-        description: "Delete a calendar event",
+        description: "Delete a calendar event. By default removes the entire item (full series for recurring events). Pass recurrenceId to remove only a single occurrence (EXDATE).",
         inputSchema: {
           type: "object",
           properties: {
             eventId: { type: "string", description: "The event ID (from listEvents results)" },
             calendarId: { type: "string", description: "The calendar ID containing the event (from listEvents results)" },
+            recurrenceId: { type: "string", description: "Optional ISO 8601 recurrence ID (from listEvents). When provided, only the matching single occurrence is excluded (EXDATE) instead of the full series." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -4871,11 +4873,142 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories, onlineMeeting, recurrence) {
+            // Leading calendar-date digits of an ISO 8601 string. For date-only
+            // values, read the date straight from these digits -- round-tripping
+            // through new Date() getters can shift the day by one depending on
+            // the host timezone (listEvents serializes all-day ids as UTC
+            // midnight, which local getters render as the previous day west of
+            // UTC).
+            const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})/;
+
+            // Parse an ISO 8601 recurrenceId into a calIDateTime matching what
+            // the rrule engine generates for RECURRENCE-ID. Uses the master's
+            // own timezone so EXDATE / occurrence-lookup comparisons succeed --
+            // parsing as UTC silently no-ops on tz'd events. Returns { recDt }
+            // on success or { error } on an unparseable input.
+            function recurrenceIdToCalDateTime(masterItem, recurrenceId) {
+              if (masterItem.startDate && masterItem.startDate.isDate) {
+                const dm = DATE_ONLY_RE.exec(String(recurrenceId).trim());
+                if (!dm) return { error: `Invalid recurrenceId: ${recurrenceId}` };
+                const recDt = cal.createDateTime();
+                recDt.resetTo(Number(dm[1]), Number(dm[2]) - 1, Number(dm[3]), 0, 0, 0, cal.dtz.floating);
+                recDt.isDate = true;
+                return { recDt };
+              }
+              const js = new Date(recurrenceId);
+              if (isNaN(js.getTime())) {
+                return { error: `Invalid recurrenceId: ${recurrenceId}` };
+              }
+              const tz = (masterItem.startDate && masterItem.startDate.timezone) || cal.dtz.defaultTimezone;
+              return { recDt: cal.dtz.jsDateToDateTime(js, tz) };
+            }
+
+            // Apply title/dates/location/description on a target item (master clone or
+            // occurrence clone). Returns { changes } on success or { error } on failure.
+            // Used by both the master-update and the single-occurrence-update paths.
+            function applyEventChanges(targetItem, title, startDate, endDate, location, description) {
+              const changes = [];
+              if (title !== undefined) { targetItem.title = title; changes.push("title"); }
+
+              if (startDate !== undefined) {
+                if (targetItem.startDate && targetItem.startDate.isDate) {
+                  const dm = DATE_ONLY_RE.exec(String(startDate).trim());
+                  if (!dm) return { error: `Invalid startDate: ${startDate}` };
+                  const dt = cal.createDateTime();
+                  dt.resetTo(Number(dm[1]), Number(dm[2]) - 1, Number(dm[3]), 0, 0, 0, cal.dtz.floating);
+                  dt.isDate = true;
+                  targetItem.startDate = dt;
+                } else {
+                  const js = new Date(startDate);
+                  if (isNaN(js.getTime())) return { error: `Invalid startDate: ${startDate}` };
+                  targetItem.startDate = cal.dtz.jsDateToDateTime(js, cal.dtz.defaultTimezone);
+                }
+                changes.push("startDate");
+              }
+
+              if (endDate !== undefined) {
+                if (targetItem.endDate && targetItem.endDate.isDate) {
+                  const dm = DATE_ONLY_RE.exec(String(endDate).trim());
+                  if (!dm) return { error: `Invalid endDate: ${endDate}` };
+                  const dt = cal.createDateTime();
+                  // iCal DTEND is exclusive for all-day -- bump by 1 day
+                  // (Date.UTC handles month/year rollover on the +1).
+                  const next = new Date(Date.UTC(Number(dm[1]), Number(dm[2]) - 1, Number(dm[3]) + 1));
+                  dt.resetTo(next.getUTCFullYear(), next.getUTCMonth(), next.getUTCDate(), 0, 0, 0, cal.dtz.floating);
+                  dt.isDate = true;
+                  targetItem.endDate = dt;
+                } else {
+                  const js = new Date(endDate);
+                  if (isNaN(js.getTime())) return { error: `Invalid endDate: ${endDate}` };
+                  targetItem.endDate = cal.dtz.jsDateToDateTime(js, cal.dtz.defaultTimezone);
+                }
+                changes.push("endDate");
+              }
+
+              if (location !== undefined) { targetItem.setProperty("LOCATION", location); changes.push("location"); }
+              if (description !== undefined) { targetItem.setProperty("DESCRIPTION", description); changes.push("description"); }
+
+              return { changes };
+            }
+
+            // Apply status/showAs/categories/onlineMeeting on a target item
+            // (master clone or occurrence clone). Appends to `changes`.
+            // Returns { error } on invalid input, {} otherwise. Used by both
+            // the master-update and the single-occurrence-update paths.
+            function applyEventMetaChanges(targetItem, status, showAs, categories, onlineMeeting, changes) {
+              if (status !== undefined) {
+                if (status === null || status === "") {
+                  targetItem.deleteProperty("STATUS");
+                } else {
+                  const normalized = normalizeEventStatus(status);
+                  if (!normalized) {
+                    return { error: `Invalid status: "${status}". Expected tentative, confirmed, or cancelled.` };
+                  }
+                  targetItem.setProperty("STATUS", normalized);
+                }
+                changes.push("status");
+              }
+              if (showAs !== undefined) {
+                if (showAs === null || showAs === "") {
+                  targetItem.deleteProperty("TRANSP");
+                } else if (showAs === "free") {
+                  targetItem.setProperty("TRANSP", "TRANSPARENT");
+                  // Also set STATUS:TENTATIVE for Thunderbird visual display unless caller overrides
+                  if (status === undefined) { targetItem.setProperty("STATUS", "TENTATIVE"); changes.push("status"); }
+                } else if (showAs === "busy") {
+                  targetItem.setProperty("TRANSP", "OPAQUE");
+                  // Also set STATUS:CONFIRMED for Thunderbird visual display unless caller overrides
+                  if (status === undefined) { targetItem.setProperty("STATUS", "CONFIRMED"); changes.push("status"); }
+                } else {
+                  return { error: `Invalid showAs: "${showAs}". Expected "busy" or "free".` };
+                }
+                changes.push("showAs");
+              }
+              // null/undefined preserves existing categories; empty array clears them.
+              if (Array.isArray(categories)) {
+                targetItem.setCategories(categories);
+                changes.push("categories");
+              }
+              if (onlineMeeting !== undefined) {
+                if (onlineMeeting) {
+                  targetItem.setProperty("X-ONLINE-MEETING-PROVIDER", "TeamsForBusiness");
+                } else {
+                  targetItem.deleteProperty("X-ONLINE-MEETING-PROVIDER");
+                  targetItem.deleteProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL");
+                }
+                changes.push("onlineMeeting");
+              }
+              return {};
+            }
+
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories, onlineMeeting, recurrence, recurrenceId) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
                 if (!calendarId) return { error: "calendarId is required" };
+                if (recurrenceId !== undefined && recurrence !== undefined) {
+                  return { error: "Cannot combine recurrence and recurrenceId: recurrence rules apply to the master event only." };
+                }
 
                 const calendar = cal.manager.getCalendars().find(c => c.id === calendarId);
                 if (!calendar) return { error: `Calendar not found: ${calendarId}` };
@@ -4893,86 +5026,44 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 }
                 if (!oldItem) return { error: `Event not found: ${eventId}` };
 
+                // ---- Single-occurrence path ----
+                if (recurrenceId !== undefined) {
+                  if (!oldItem.recurrenceInfo) {
+                    return { error: "Event is not recurring; recurrenceId cannot be applied" };
+                  }
+                  const rid = recurrenceIdToCalDateTime(oldItem, recurrenceId);
+                  if (rid.error) return { error: rid.error };
+                  const occurrence = oldItem.recurrenceInfo.getOccurrenceFor(rid.recDt);
+                  if (!occurrence) {
+                    return { error: `No occurrence found at recurrenceId: ${recurrenceId}` };
+                  }
+
+                  const modOcc = occurrence.clone();
+                  const r = applyEventChanges(modOcc, title, startDate, endDate, location, description);
+                  if (r.error) return { error: r.error };
+                  const meta = applyEventMetaChanges(modOcc, status, showAs, categories, onlineMeeting, r.changes);
+                  if (meta.error) return { error: meta.error };
+                  if (r.changes.length === 0) return { error: "No changes specified" };
+                  if (modOcc.startDate && modOcc.endDate && modOcc.endDate.compare(modOcc.startDate) <= 0) {
+                    return { error: "endDate must be after startDate" };
+                  }
+
+                  // Pass the modified occurrence itself, not a master clone:
+                  // providers detect parentItem and register the exception on
+                  // the series. Sending the master would make OWL/Exchange
+                  // target the whole series and overwrite every occurrence on
+                  // the next sync.
+                  await calendar.modifyItem(modOcc, occurrence);
+                  return { success: true, updated: r.changes, mode: "occurrence", recurrenceId };
+                }
+
+                // ---- Master / series path (default) ----
                 const newItem = oldItem.clone();
-                const changes = [];
-
-                if (title !== undefined) { newItem.title = title; changes.push("title"); }
-
-                if (startDate !== undefined) {
-                  const js = new Date(startDate);
-                  if (isNaN(js.getTime())) return { error: `Invalid startDate: ${startDate}` };
-                  if (newItem.startDate && newItem.startDate.isDate) {
-                    const dt = cal.createDateTime();
-                    dt.resetTo(js.getFullYear(), js.getMonth(), js.getDate(), 0, 0, 0, cal.dtz.floating);
-                    dt.isDate = true;
-                    newItem.startDate = dt;
-                  } else {
-                    newItem.startDate = cal.dtz.jsDateToDateTime(js, cal.dtz.defaultTimezone);
-                  }
-                  changes.push("startDate");
-                }
-
-                if (endDate !== undefined) {
-                  const js = new Date(endDate);
-                  if (isNaN(js.getTime())) return { error: `Invalid endDate: ${endDate}` };
-                  if (newItem.endDate && newItem.endDate.isDate) {
-                    const dt = cal.createDateTime();
-                    // iCal DTEND is exclusive for all-day -- bump by 1 day
-                    const next = new Date(js.getFullYear(), js.getMonth(), js.getDate());
-                    next.setDate(next.getDate() + 1);
-                    dt.resetTo(next.getFullYear(), next.getMonth(), next.getDate(), 0, 0, 0, cal.dtz.floating);
-                    dt.isDate = true;
-                    newItem.endDate = dt;
-                  } else {
-                    newItem.endDate = cal.dtz.jsDateToDateTime(js, cal.dtz.defaultTimezone);
-                  }
-                  changes.push("endDate");
-                }
-
-                if (location !== undefined) { newItem.setProperty("LOCATION", location); changes.push("location"); }
-                if (description !== undefined) { newItem.setProperty("DESCRIPTION", description); changes.push("description"); }
-                if (status !== undefined) {
-                  if (status === null || status === "") {
-                    newItem.deleteProperty("STATUS");
-                  } else {
-                    const normalized = normalizeEventStatus(status);
-                    if (!normalized) {
-                      return { error: `Invalid status: "${status}". Expected tentative, confirmed, or cancelled.` };
-                    }
-                    newItem.setProperty("STATUS", normalized);
-                  }
-                  changes.push("status");
-                }
-                if (showAs !== undefined) {
-                  if (showAs === null || showAs === "") {
-                    newItem.deleteProperty("TRANSP");
-                  } else if (showAs === "free") {
-                    newItem.setProperty("TRANSP", "TRANSPARENT");
-                    // Also set STATUS:TENTATIVE for Thunderbird visual display unless caller overrides
-                    if (status === undefined) { newItem.setProperty("STATUS", "TENTATIVE"); changes.push("status"); }
-                  } else if (showAs === "busy") {
-                    newItem.setProperty("TRANSP", "OPAQUE");
-                    // Also set STATUS:CONFIRMED for Thunderbird visual display unless caller overrides
-                    if (status === undefined) { newItem.setProperty("STATUS", "CONFIRMED"); changes.push("status"); }
-                  } else {
-                    return { error: `Invalid showAs: "${showAs}". Expected "busy" or "free".` };
-                  }
-                  changes.push("showAs");
-                }
-                // null/undefined preserves existing categories; empty array clears them.
-                if (Array.isArray(categories)) {
-                  newItem.setCategories(categories);
-                  changes.push("categories");
-                }
-                if (onlineMeeting !== undefined) {
-                  if (onlineMeeting) {
-                    newItem.setProperty("X-ONLINE-MEETING-PROVIDER", "TeamsForBusiness");
-                  } else {
-                    newItem.deleteProperty("X-ONLINE-MEETING-PROVIDER");
-                    newItem.deleteProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL");
-                  }
-                  changes.push("onlineMeeting");
-                }
+                const r = applyEventChanges(newItem, title, startDate, endDate, location, description);
+                if (r.error) return { error: r.error };
+                const changes = r.changes;
+                const meta = applyEventMetaChanges(newItem, status, showAs, categories, onlineMeeting, changes);
+                if (meta.error) return { error: meta.error };
 
                 if (recurrence !== undefined) {
                   try {
@@ -5004,7 +5095,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function deleteEvent(eventId, calendarId) {
+            async function deleteEvent(eventId, calendarId, recurrenceId) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -5023,6 +5114,24 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   item = all.find(i => i.id === eventId) || null;
                 }
                 if (!item) return { error: `Event not found: ${eventId}` };
+
+                if (recurrenceId !== undefined) {
+                  if (!item.recurrenceInfo) {
+                    return { error: "Event is not recurring; recurrenceId cannot be applied" };
+                  }
+                  const rid = recurrenceIdToCalDateTime(item, recurrenceId);
+                  if (rid.error) return { error: rid.error };
+                  // removeOccurrenceAt happily EXDATEs a date with no
+                  // occurrence; validate first so a miss is an error, not a
+                  // silent success that leaves the real occurrence in place.
+                  if (!item.recurrenceInfo.getOccurrenceFor(rid.recDt)) {
+                    return { error: `No occurrence found at recurrenceId: ${recurrenceId}` };
+                  }
+                  const newItem = item.clone();
+                  newItem.recurrenceInfo.removeOccurrenceAt(rid.recDt);
+                  await calendar.modifyItem(newItem, item);
+                  return { success: true, deleted: eventId, recurrenceId, mode: "occurrence" };
+                }
 
                 const isRecurring = !!item.recurrenceInfo;
                 await calendar.deleteItem(item);
@@ -8349,9 +8458,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories, args.onlineMeeting, args.recurrence);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories, args.onlineMeeting, args.recurrence, args.recurrenceId);
                 case "deleteEvent":
-                  return await deleteEvent(args.eventId, args.calendarId);
+                  return await deleteEvent(args.eventId, args.calendarId, args.recurrenceId);
                 case "listCategories":
                   return listCategories();
                 case "createTask":

--- a/test/event-rrule.test.cjs
+++ b/test/event-rrule.test.cjs
@@ -1,0 +1,136 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+// Mirrors the RRULE handling in api.js (normalizeRRule / extractRRuleFromItem).
+// XPCOM is unavailable in node:test, so this covers only the pure string rules
+// and the parentItem fallback -- not calIRecurrenceInfo itself.
+
+function normalizeRRule(recurrence) {
+  const body = String(recurrence).trim().replace(/^rrule:/i, "").trim();
+  if (!body) throw new Error("Empty recurrence rule");
+  const m = /(?:^|;)FREQ=([^;]*)/i.exec(body);
+  if (!m) throw new Error("Recurrence rule must contain a FREQ part (e.g. FREQ=WEEKLY)");
+  const freq = m[1].toUpperCase();
+  if (freq === "SECONDLY" || freq === "MINUTELY") {
+    throw new Error(`FREQ=${freq} is not supported: Thunderbird's recurrence engine generates no occurrences for it`);
+  }
+  return "RRULE:" + body;
+}
+
+function extractRRuleFromItem(item) {
+  const rinfo = (item.parentItem || item).recurrenceInfo;
+  if (!rinfo) return null;
+  try {
+    const rules = rinfo.getRecurrenceItems();
+    for (const r of rules) {
+      if (r && typeof r.icalString === "string") {
+        const line = r.icalString.replace(/\r?\n$/, "");
+        if (line.startsWith("RRULE:")) return line.slice("RRULE:".length);
+      }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function mockRecurrenceInfo(icalStrings) {
+  return {
+    getRecurrenceItems() {
+      return icalStrings.map(s => ({ icalString: s }));
+    },
+  };
+}
+
+describe("normalizeRRule", () => {
+  it("adds the RRULE: prefix when missing", () => {
+    assert.equal(normalizeRRule("FREQ=DAILY;COUNT=10"), "RRULE:FREQ=DAILY;COUNT=10");
+  });
+
+  it("keeps an existing RRULE: prefix without doubling it", () => {
+    assert.equal(normalizeRRule("RRULE:FREQ=DAILY"), "RRULE:FREQ=DAILY");
+  });
+
+  it("accepts a lowercase rrule: prefix without producing RRULE:rrule:", () => {
+    assert.equal(normalizeRRule("rrule:FREQ=DAILY"), "RRULE:FREQ=DAILY");
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(normalizeRRule("  RRULE:FREQ=WEEKLY;BYDAY=MO  "), "RRULE:FREQ=WEEKLY;BYDAY=MO");
+    assert.equal(normalizeRRule("rrule: FREQ=WEEKLY"), "RRULE:FREQ=WEEKLY");
+  });
+
+  it("rejects FREQ=SECONDLY and FREQ=MINUTELY", () => {
+    assert.throws(() => normalizeRRule("FREQ=SECONDLY"), /SECONDLY/);
+    assert.throws(() => normalizeRRule("RRULE:FREQ=MINUTELY;INTERVAL=5"), /MINUTELY/);
+    assert.throws(() => normalizeRRule("freq=minutely"), /MINUTELY/);
+  });
+
+  it("accepts every expandable frequency", () => {
+    for (const freq of ["HOURLY", "DAILY", "WEEKLY", "MONTHLY", "YEARLY"]) {
+      assert.equal(normalizeRRule(`FREQ=${freq}`), `RRULE:FREQ=${freq}`);
+    }
+  });
+
+  it("only matches FREQ as a property name, not inside another value", () => {
+    // UNTIL value contains no FREQ; a BYDAY rule with FREQ later still parses.
+    assert.equal(
+      normalizeRRule("BYDAY=MO;FREQ=WEEKLY"),
+      "RRULE:BYDAY=MO;FREQ=WEEKLY",
+    );
+  });
+
+  it("rejects empty and prefix-only rules", () => {
+    assert.throws(() => normalizeRRule(""), /Empty/);
+    assert.throws(() => normalizeRRule("   "), /Empty/);
+    assert.throws(() => normalizeRRule("RRULE:"), /Empty/);
+  });
+
+  it("rejects rules without a FREQ part", () => {
+    assert.throws(() => normalizeRRule("BYDAY=MO,WE,FR"), /FREQ/);
+    assert.throws(() => normalizeRRule("RRULE:COUNT=10;INTERVAL=2"), /FREQ/);
+  });
+});
+
+describe("extractRRuleFromItem", () => {
+  it("returns the RRULE body without prefix", () => {
+    const item = { recurrenceInfo: mockRecurrenceInfo(["RRULE:FREQ=WEEKLY;BYDAY=MO,TU"]) };
+    assert.equal(extractRRuleFromItem(item), "FREQ=WEEKLY;BYDAY=MO,TU");
+  });
+
+  it("trims the trailing CRLF an icalString may carry", () => {
+    const item = { recurrenceInfo: mockRecurrenceInfo(["RRULE:FREQ=DAILY;COUNT=3\r\n"]) };
+    assert.equal(extractRRuleFromItem(item), "FREQ=DAILY;COUNT=3");
+  });
+
+  it("reads the rule from parentItem on occurrence proxies", () => {
+    const master = { recurrenceInfo: mockRecurrenceInfo(["RRULE:FREQ=MONTHLY"]) };
+    const occurrence = { parentItem: master, recurrenceInfo: null };
+    assert.equal(extractRRuleFromItem(occurrence), "FREQ=MONTHLY");
+  });
+
+  it("skips non-RRULE recurrence items (EXDATE, RDATE)", () => {
+    const item = {
+      recurrenceInfo: mockRecurrenceInfo([
+        "EXDATE:20260101T100000Z\r\n",
+        "RRULE:FREQ=YEARLY\r\n",
+      ]),
+    };
+    assert.equal(extractRRuleFromItem(item), "FREQ=YEARLY");
+  });
+
+  it("returns null for RDATE-only recurrences", () => {
+    const item = { recurrenceInfo: mockRecurrenceInfo(["RDATE:20260101T100000Z"]) };
+    assert.equal(extractRRuleFromItem(item), null);
+  });
+
+  it("returns null for non-recurring items", () => {
+    assert.equal(extractRRuleFromItem({ recurrenceInfo: null }), null);
+    assert.equal(extractRRuleFromItem({}), null);
+  });
+
+  it("degrades to null when the provider throws", () => {
+    const item = { recurrenceInfo: { getRecurrenceItems() { throw new Error("quirk"); } } };
+    assert.equal(extractRRuleFromItem(item), null);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **per-occurrence** delete and update to `deleteEvent` / `updateEvent`
via a new `recurrenceId` parameter. Today both tools operate on the whole
series for recurring events — you can't say "cancel only next Monday's
stand-up" or "this one occurrence moves to 2pm".

> ⚠️ **Stacked on #94** (`feat(events): support RRULE recurrence in
> create/update/list`). The diff currently includes that PR's changes; it
> will narrow to just the per-occurrence changes once #94 merges. The
> per-occurrence functionality is independent of #94 at runtime — a
> Thunderbird user can already have RRULE events created elsewhere
> (Thunderbird UI, CalDAV server) — but the helper functions added by #94
> live in the same area of the file, hence the stack.

## Changes

- **`deleteEvent`** accepts an optional `recurrenceId`. When set on a
  recurring master, only that single occurrence is removed via
  `calIRecurrenceInfo.removeOccurrenceAt()` (EXDATE) instead of deleting
  the whole series.
- **`updateEvent`** accepts the same `recurrenceId`. When set, only that
  occurrence is modified via `calIRecurrenceInfo.modifyException()`
  (createException) instead of the master event. Cannot be combined with
  the `recurrence` rule parameter — rules apply to the master only, and
  the call returns a clear error.
- `updateEvent` internals: title/dates/location/description handling is
  extracted into a small `applyEventChanges` helper shared by both the
  master-update and per-occurrence-update paths.
- A `recurrenceIdToCalDateTime(masterItem, recurrenceId)` helper is shared
  by both `deleteEvent` and `updateEvent`.

## Timezone fix

The iCal `RECURRENCE-ID` generated by the rrule engine uses the master's
own timezone, not UTC. Parsing the ISO recurrenceId as UTC caused
`removeOccurrenceAt()` and `getOccurrenceFor()` to silently no-op —
`modifyItem()` succeeded but produced no actual EXDATE. The helper parses
the recurrenceId in `item.startDate.timezone` (falling back to
`defaultTimezone`), which yields the same instant with the correct tz for
the iCal equality check.

## Test plan

- [x] Weekly stand-up: `deleteEvent(eventId, calendarId, recurrenceId)`
      with next Monday's ISO timestamp adds an EXDATE; that one occurrence
      disappears, the rest of the series stays.
- [x] `updateEvent` with `recurrenceId` and a new `startDate`: that one
      occurrence shifts, the master is untouched.
- [x] `updateEvent` with both `recurrence` and `recurrenceId`: rejected
      with a clear error.
- [x] `deleteEvent` with `recurrenceId` on a non-recurring event: error
      `"Event is not recurring; recurrenceId cannot be applied"`.
- [x] `updateEvent` with `recurrenceId` not matching any occurrence: error
      `"No occurrence found at recurrenceId: ..."`.
- [x] CalDAV calendar: changes survive a server round-trip (server-side
      EXDATE / modified instance both appear).