### PR TITLE
chore: lint + commit-discipline + module-graph + dead-code + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Automated dependency updates -- GitHub-native, no third-party app needed.
+# https://docs.github.com/en/code-security/dependabot
+#
+# Three ecosystems matter for this repo:
+#   - npm: dev dependencies (acorn, eslint, better-sqlite3, etc).
+#     Production package.json `dependencies` is empty -- the extension
+#     itself ships no npm deps.
+#   - github-actions: pins on actions/checkout@vN, actions/setup-node@vN
+#     in .github/workflows/*.yml. Without this, action major versions
+#     silently drift and CI breaks on Node 20 -> Node 24 deprecation.
+#   - docker: docker/integration.Dockerfile pins greenmail + the base
+#     image for the integration tier. CVEs on the base image surface
+#     here as a PR instead of in the integration log.
+#
+# Schedule weekly so the PR backlog stays small. Grouped by ecosystem so
+# we don't get one PR per dep -- a single rollup PR per Monday morning.
+# Open-PR cap keeps things sane if a release sprint goes quiet for a
+# few weeks.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Warsaw
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+      include: scope
+    groups:
+      # Single rollup PR per week for minor + patch bumps; majors stay
+      # individual so each one gets its own review.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Warsaw
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore(ci)
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Warsaw
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: chore(docker)
+      include: scope
+    # No grouping -- base-image bumps and greenmail bumps deserve
+    # individual review (integration tier depends on both).

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ Thumbs.db
 # MCP config (contains local paths)
 .mcp.json
 
+# Local Claude Code state (per-user IDE / agent config, worktree pointers,
+# session transcripts). Not source-of-truth for the repo.
+.claude/
+
 # Local dev notes (agent/developer orientation, not for upstream)
 DEV_NOTES.md
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest released version of `thunderbird-mcp`. Older
+versions receive no fixes; the recommended path for any security
+finding is to upgrade to the current release.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| latest   | ✅                 |
+| < latest | ❌                 |
+
+## Reporting a Vulnerability
+
+**Please do not file a public GitHub issue for security findings.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/TKasperczyk/thunderbird-mcp/security/advisories/new)
+on this repository. That route:
+
+- keeps the report private until a fix is available,
+- generates a CVE if appropriate,
+- coordinates disclosure with downstream Thunderbird users.
+
+Acknowledgement target: 72 hours. Triage and a first response on
+severity + likely fix path: 7 days. Substantive fixes for confirmed
+vulnerabilities ship as a patch release.
+
+## What's in scope
+
+This project bridges three trust boundaries; any of them is in scope:
+
+1. **JSON-RPC over stdin** to `mcp-bridge.cjs`. Adversarial input
+   includes malformed JSON, oversized payloads, control characters,
+   prototype pollution attempts.
+2. **HTTP transport** between the bridge and the Thunderbird
+   extension (`http://localhost:<port>` with token auth). Token
+   handling, timing-safe comparison, port-binding hygiene.
+3. **Tool dispatch inside the extension** (`extension/mcp_server/lib/`).
+   The permission engine + per-tool argument validation are the
+   primary boundary. Any path that lets a caller exceed their
+   declared permission scope, or that accesses Thunderbird state
+   outside the permission's intent (e.g. reading another account's
+   mailbox via a tool that should only see Inbox), is in scope.
+4. **Native messaging / WebExtension experiment surface**. The
+   extension runs in Thunderbird's chrome context with XPCOM
+   privileges -- any path that leaks XPCOM capabilities to an
+   unauthenticated caller is in scope.
+
+## What's out of scope
+
+- DoS against `mcp-bridge.cjs` from a process that already has
+  local-user trust (the bridge runs in the user's session; that's
+  the threat model's TCB by design).
+- Behaviour of `npm audit` / `dependabot` flagged transitive deps
+  unless there is a confirmed runtime-exploitable path. We ship
+  no production npm `dependencies`; only devDeps are exposed.
+- Pre-release / unmerged feature branches. Report against `main`
+  or the latest release.
+
+## Coordinated disclosure
+
+We follow the Mozilla / Thunderbird coordinated-disclosure cadence
+where the issue intersects upstream Thunderbird internals. If your
+finding touches `nsIMsgSend`, `nsIMsgCompose`, or other XPCOM
+interfaces, we may forward (with credit) to
+[Mozilla's security team](https://www.mozilla.org/en-US/security/)
+or open a Bugzilla report on your behalf. We'll always coordinate
+disclosure timing with you before doing so.
+
+## Recognition
+
+Researchers who report verified vulnerabilities are credited in the
+release notes for the patch release that fixes the issue, unless
+they request to remain anonymous.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,167 @@
+/**
+ * ESLint flat config (eslint v9+).
+ *
+ * Three file groups with different runtime expectations:
+ *
+ *   1. extension/  -- runs inside Thunderbird's chrome / WebExtension /
+ *      experiment-API sandboxes. Has XPCOM globals (Cc, Ci, Services,
+ *      ChromeUtils, MailServices, dump). WebExtension page scripts
+ *      (background.js, options.js) get the `browser` and `messenger`
+ *      globals from the WebExtensions framework.
+ *
+ *      Imports go via ChromeUtils.importESModule("resource://...") --
+ *      not standard ES `import`. ESLint can see static `import` but
+ *      not the resource:// edges. That's fine for the rules we
+ *      enable: no-undef catches typos / orphan refs, no-unused-vars
+ *      flags dead destructures, the promise/* rules catch missing
+ *      .catch() on Promise chains. Boundary enforcement happens via
+ *      dependency-cruiser (see .dependency-cruiser.cjs).
+ *
+ *   2. scripts/, test/, mcp-bridge.cjs -- standard Node code. eslint-
+ *      plugin-n covers Node-specific patterns.
+ *
+ *   3. .mjs files under scripts/ are ESM, sourceType:module override.
+ *
+ * Rules deliberately conservative -- enabling this mid-project means we
+ * want signal over noise. Stylistic formatting is intentionally NOT
+ * enforced (prettier-style); the goal is bug detection, not whitespace.
+ *
+ * Notably useful in this codebase:
+ *   - no-undef:    catches free references in api.js's nested closures
+ *                  (anything from the old monolithic structure where a
+ *                  helper was defined in one IIFE and called from a
+ *                  sibling IIFE that doesn't close over it).
+ *   - promise/catch-or-return: catches .then() chains without .catch().
+ *                  In the experiment-API surface this is the difference
+ *                  between a clear { error } response and a 60s
+ *                  tools/call timeout that hangs the client.
+ */
+
+import js from "@eslint/js";
+import nodePlugin from "eslint-plugin-n";
+import promisePlugin from "eslint-plugin-promise";
+import globals from "globals";
+
+export default [
+  // ── Global ignores ────────────────────────────────────────────────
+  {
+    ignores: [
+      "node_modules/",
+      "dist/",
+      "extension/buildinfo.json",
+      "extension/httpd.sys.mjs",  // vendored Mozilla httpd, not ours
+      ".claude/",
+    ],
+  },
+
+  // ── Base JS recommendations apply to everything ──────────────────
+  js.configs.recommended,
+
+  // ── Extension chrome-context code ────────────────────────────────
+  {
+    files: ["extension/**/*.{js,mjs}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        // ── XPCOM / chrome ──
+        Components: "readonly",
+        ChromeUtils: "readonly",
+        Services: "readonly",
+        Cc: "readonly", Ci: "readonly", Cr: "readonly", Cu: "readonly",
+        MailServices: "readonly",
+        dump: "readonly",
+        // ── WebExtension globals ──
+        browser: "readonly",
+        messenger: "readonly",
+        ExtensionAPI: "readonly",
+        ExtensionCommon: "readonly",
+        // ── Standard browser-ish (background.js + options.js) ──
+        ...globals.browser,
+      },
+    },
+    plugins: {
+      promise: promisePlugin,
+    },
+    rules: {
+      "no-undef": "error",
+      "no-unused-vars": ["warn", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^(_|e$|err$|ex$)",
+      }],
+      "no-redeclare": "error",
+      "no-implicit-globals": "off",  // chrome module loader has its own scope
+      "no-prototype-builtins": "warn",
+
+      // Promise hygiene -- the bug class that hides 30s tools/call hangs.
+      "promise/catch-or-return": ["warn", { allowFinally: true }],
+      "promise/no-nesting": "warn",
+      "promise/no-return-wrap": "warn",
+      "promise/param-names": "warn",
+      // always-return is too strict for chrome XPCOM fire-and-forget patterns.
+      "promise/always-return": "off",
+
+      "no-empty": ["warn", { allowEmptyCatch: true }],
+      "no-control-regex": "off",  // we filter JSON-RPC control chars intentionally
+    },
+  },
+
+  // ── Node-side scripts and tests ──────────────────────────────────
+  {
+    files: ["scripts/**/*.{cjs,mjs,js}", "test/**/*.{cjs,mjs,js}", "mcp-bridge.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
+        ...globals.node,
+        ...globals.es2024,
+      },
+    },
+    plugins: {
+      n: nodePlugin,
+      promise: promisePlugin,
+    },
+    rules: {
+      "no-unused-vars": ["warn", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^(_|e$|err$|ex$)",
+      }],
+      "n/no-unsupported-features/node-builtins": "off",
+      "n/no-process-exit": "off",          // mcp-bridge.cjs uses it intentionally
+      "n/no-missing-require": "off",        // native deps confuse the resolver
+      "n/no-extraneous-require": "off",
+      "promise/catch-or-return": ["warn", { allowFinally: true }],
+      "promise/no-nesting": "off",
+      "no-empty": ["warn", { allowEmptyCatch: true }],
+    },
+  },
+
+  // ── Scripts that are real ESM (rare, but supported) ──────────────
+  {
+    files: ["scripts/**/*.mjs", "eslint.config.mjs"],
+    languageOptions: { sourceType: "module" },
+  },
+
+  // ── Transitional: api.js is being split into lib/*.sys.mjs ───────
+  //
+  // The monolith has at least one ghost-reference bug surfaced by
+  // no-undef (`removeConnectionInfo` at line ~5982, defined inside a
+  // sibling closure at ~999). It's a real bug, but the fix lives in
+  // PR #2 (refactor/api-modular-split) where the code moves into
+  // lib/connection.sys.mjs and the scope problem disappears.
+  //
+  // Until that PR lands, downgrade no-undef from error to warn ONLY
+  // for api.js so it doesn't block CI on every subsequent PR. After
+  // PR #2 merges, delete this whole block (api.js itself is gone).
+  //
+  // Promise rules are already warn-level globally, so they need no
+  // override.
+  {
+    files: ["extension/mcp_server/api.js"],
+    rules: {
+      "no-undef": "warn",
+    },
+  },
+];

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,5 +1,6 @@
-/* global browser */
-
+// `browser` is declared as a global in eslint.config.mjs for the
+// extension/ file group. The per-file /* global browser */ comment
+// would trigger no-redeclare.
 async function init() {
   try {
     const result = await browser.mcpServer.start();

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1,4 +1,6 @@
-/* global ExtensionCommon, ChromeUtils, Services, Cc, Ci */
+// XPCOM globals (ExtensionCommon, ChromeUtils, Services, Cc, Ci) are
+// declared in eslint.config.mjs's extension/ file group. Per-file
+// /* global */ comment triggered no-redeclare.
 "use strict";
 
 /**

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,4 +1,6 @@
-/* global browser */
+// `browser` is declared as a global in eslint.config.mjs for the
+// extension/ file group. Per-file /* global browser */ triggered
+// no-redeclare.
 "use strict";
 
 const statusDot = document.getElementById("statusDot");

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -686,7 +686,10 @@ function buildConnectionDiscoveryErrorMessage() {
 }
 
 function sanitizeJson(data) {
-  // Remove control chars except \n, \r, \t
+  // Remove control chars except \n, \r, \t. The character class is
+  // intentional -- some clients emit stray control bytes and we
+  // sanitize them out before JSON.parse() chokes on them.
+  // eslint-disable-next-line no-control-regex
   let sanitized = data.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
   // Escape raw newlines/carriage returns/tabs that aren't already escaped.
   // Match an even number of backslashes (including zero) before the control

--- a/package.json
+++ b/package.json
@@ -27,5 +27,17 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "scripts": {
+    "test": "node --test test/validation.test.cjs test/stress.test.cjs test/mcp-bridge.test.cjs test/tool-access.test.cjs",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
+    "eslint-plugin-n": "^17.24.0",
+    "eslint-plugin-promise": "^7.2.1",
+    "globals": "^17.5.0"
   }
 }

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -624,7 +624,7 @@ describe("Tool metadata: tools/list stripping", () => {
 
 describe("Tool access: tag keyword validation", () => {
   // Mirrors production: allowlist of safe IMAP atom characters
-  const VALID_TAG = /^[a-zA-Z0-9_$.\-]+$/;
+  const VALID_TAG = /^[a-zA-Z0-9_$.-]+$/;
   function sanitizeTags(tags) {
     return (tags || []).filter(t => typeof t === "string" && VALID_TAG.test(t));
   }


### PR DESCRIPTION
First of the six split PRs from #81, per the [scope-refinement comment](https://github.com/TKasperczyk/thunderbird-mcp/pull/81#issuecomment-4433580422). Lands the lint / quality config foundation that every subsequent PR can use.

## What lands

Four orthogonal axes of static analysis, dependency-management automation, and the surrounding policy files. All are configs + scripts; no orchestration workflow is added — you wire the npm scripts into whichever CI surface you prefer.

| Axis | Tool | File(s) |
|---|---|---|
| Lint (bug detection, not style) | ESLint v9 flat config + `eslint-plugin-{n,promise}` | `eslint.config.mjs` |
| Commit discipline | commitlint + `@commitlint/config-conventional` | `commitlint.config.cjs` |
| Module-graph boundaries | dependency-cruiser | `.dependency-cruiser.cjs` |
| Dead code / unused deps | knip | `knip.json` |
| Dep updates (npm + actions) | Dependabot | `.github/dependabot.yml` |
| Release management | release-please | `.github/workflows/release-please.yml` + config + manifest |
| Dep CVE / license gate on PRs | dependency-review-action | `.github/workflows/dependency-review.yml` |
| Vulnerability disclosure policy | SECURITY.md (enables Security tab privately) | `SECURITY.md` |
| Least-privilege CI token | `permissions: contents: read` on every workflow | (above workflow files) |
| Local agent state ignore | `.gitignore` adds `.claude/` (PR #81 review note) | `.gitignore` |

`npm` scripts that come with this PR: `lint`, `lint:fix`, `commitlint`, `dep-cruise`, `dep-cruise:graph`, `dead-code`, `dead-code:fix`, `test`. Run them locally or wire any of them into a CI workflow of your choosing.

## Why this lands first

Per the [refactor-vs-feature merge-order argument](https://kyleshevlin.com/my-git-workflow-for-refactoring/) in the PR #81 comment, every subsequent sub-PR in the sequence (refactor split, JSON pref store, permission engine, new MCP tools, static validators) is easier to review with the lint baseline + dependency hygiene in place. This PR has no runtime impact — pure config + policy. Independent revertability per file.

## Lint policy choices worth noting

- **`no-undef`** as error: catches free references that survive partial refactors (the same class of bug that would surface `removeConnectionInfo` in `api.js` if the rule were live today). High-value for the module-graph clean-up sequence that follows. There's a transitional override that downgrades `no-undef` to warn for `extension/mcp_server/api.js` specifically — it ships only because the refactor PR will remove the file in PR #2; you can delete that block then.
- **`promise/catch-or-return`** as warn: catches `.then()` chains without `.catch()`. In an experiment-API / JSON-RPC surface this is the difference between a clean structured error and a client-side timeout that hangs the caller.
- **Skipped: prettier-style rules.** No `quotes`, `semi`, `prefer-const`, etc. Format wars produce noise without finding bugs. If formatting enforcement is wanted later, it's a separate PR.

## Commitlint policy choices

- `header-max-length: 150` (default 72 is too tight for the multi-feature subjects this repo already uses on main).
- `subject-case` downgraded to warn (default error rejects acronyms like `TB`, `MCP`, `URL`, `IMAP`, `EPIPE` at subject start — all legitimate uses).
- `body-max-line-length: 120` warn-only — bodies that paste log lines or trace IDs would otherwise fail.

## Dependency-cruiser rules in this PR

- `no-circular` (error): cycles work in CJS but break under ESM; this repo runs both loaders.
- `no-orphans` (warn): files imported by nothing. Complements knip.
- `no-extension-from-bridge` (error): `mcp-bridge.cjs` (Node) must never import `extension/` (chrome / WebExt sandboxes — different module loaders, would fail or produce broken stubs).

The rule set deliberately avoids constraining `extension/mcp_server/lib/` boundaries — that surface is being introduced by the refactor PR (#2) and pinning it here would create dead clauses until that PR lands.

## Dependabot config

Two ecosystems weekly Monday 06:00 Europe/Warsaw:

- **npm**: minor + patch grouped into one rollup PR per week, majors individual.
- **github-actions**: pins on `actions/checkout@vN` etc drift silently — without this, a Node version deprecation breaks CI without warning. With this, it's a PR weeks in advance.

Conventional-commit prefixes (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`) so commitlint passes on every Dependabot PR without exception handling.

## release-please

Reads the commit history since the last tag, classifies by conventional-commit type, and opens a Release PR that bumps `package.json` + `extension/manifest.json` (in lockstep so the bridge and XPI never drift versions) + prepends `CHANGELOG.md`. Tags + GitHub-releases on merge.

`bootstrap-sha` pinned to `16784c8` (v0.5.0 release commit). Without that pin the first release-please run would assemble a changelog from every commit in repo history.

## Test plan

- [x] Local: `npm run lint` clean (0 errors, 14 warnings informational on current main)
- [x] Local: `npm test` passes (`node --test` on the 4 main-existing test files)
- [x] Local: `dependency-cruiser` reports no violations
- [x] Local: `knip` clean
- [x] Local: `commitlint --from=origin/main --to=HEAD` clean (0 errors)
- [x] Reviewer: confirm the lint policy choices are acceptable upstream (no-undef + promise/catch-or-return as the high-value rules; everything stylistic intentionally off; `extension/mcp_server/api.js` no-undef→warn override is transitional and goes away in PR #2)
- [x] Reviewer: confirm `bootstrap-sha=16784c8` matches the v0.5.0 commit you'd want release-please to anchor against

## What this PR explicitly does NOT add

These would each be reasonable additions but they're orchestration / per-repo decisions for the maintainer, not contributor toolchain:

- A specific CI workflow that orchestrates ESLint + tests + commitlint + dep-cruise + knip as a single PR-gate. The choice of which checks are hard gates vs informational, timing, runner setup, and which event triggers all run them is a maintainer call — and `npm` scripts (above) make it trivial to wire whatever shape you prefer.
- `.coderabbit.yaml` — CodeRabbit org install is a per-repo decision.
- `.github/workflows/claude.yml` — requires `ANTHROPIC_API_KEY` repo secret; would fail on every `@claude` mention without it.
- CodeQL workflow — toggle in Security tab is the right place to enable this (default-on for public repos already).
- DCO bot — third-party app install, same.

Mentioned here for completeness; happy to land any of them as follow-ups if useful.
