### PR TITLE
Use package version when building manifest

### DIFF
--- a/scripts/build-xpi.cjs
+++ b/scripts/build-xpi.cjs
@@ -104,6 +104,16 @@ function addDir(zip, dir, prefix) {
   }
 }
 
+function readPackageVersion() {
+  const packageFile = path.join(PROJECT_DIR, 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
+    return typeof pkg.version === 'string' && pkg.version ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
 // Stamp buildinfo.json with git describe version and timestamp
 const { execSync } = require('child_process');
 const BUILDINFO_FILE = path.join(EXT_DIR, 'buildinfo.json');
@@ -125,12 +135,14 @@ try {
   const buildInfo = JSON.stringify({ version, builtAt: new Date().toISOString() });
   fs.writeFileSync(BUILDINFO_FILE, buildInfo);
 
-  // Update manifest.json version from git tag (Thunderbird requires numeric version)
+  // Update manifest.json version from package.json.
   const MANIFEST_FILE = path.join(EXT_DIR, 'manifest.json');
   const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, 'utf8'));
-  const tagMatch = version.match(/^v?(\d+\.\d+(?:\.\d+)?)/);
-  if (tagMatch) {
-    manifest.version = tagMatch[1];
+  const packageVersion = readPackageVersion();
+  const fallbackTagMatch = version.match(/^v?(\d+\.\d+(?:\.\d+)?)/);
+  const manifestVersion = packageVersion || (fallbackTagMatch ? fallbackTagMatch[1] : null);
+  if (manifestVersion) {
+    manifest.version = manifestVersion;
     fs.writeFileSync(MANIFEST_FILE, JSON.stringify(manifest, null, 2) + '\n');
   }
 } catch {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,17 @@ if git -C "$PROJECT_DIR" describe --tags --always > /dev/null 2>&1; then
 elif git -C "$PROJECT_DIR" rev-parse --short HEAD > /dev/null 2>&1; then
   VERSION=$(git -C "$PROJECT_DIR" rev-parse --short HEAD)
 fi
+PACKAGE_VERSION=""
+if command -v node > /dev/null 2>&1; then
+  PACKAGE_VERSION=$(node -e "
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const pkg = JSON.parse(fs.readFileSync(path.join('$PROJECT_DIR', 'package.json'), 'utf8'));
+      process.stdout.write(typeof pkg.version === 'string' ? pkg.version : '');
+    } catch {}
+  ")
+fi
 # Append +dirty if there are uncommitted changes
 if ! git -C "$PROJECT_DIR" diff --quiet 2>/dev/null || ! git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
   VERSION="${VERSION}+dirty"
@@ -31,22 +42,25 @@ BUILT_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 echo "{\"version\":\"$VERSION\",\"builtAt\":\"$BUILT_AT\"}" > "$EXTENSION_DIR/buildinfo.json"
 echo "Build version: $VERSION"
 
-# Update manifest.json version from git tag (Thunderbird requires numeric version)
-TAG_VERSION=$(echo "$VERSION" | grep -oE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?' | sed 's/^v//')
-if [ -n "$TAG_VERSION" ]; then
+# Update manifest.json version from package.json.
+MANIFEST_VERSION="$PACKAGE_VERSION"
+if [ -z "$MANIFEST_VERSION" ]; then
+  MANIFEST_VERSION=$(echo "$VERSION" | grep -oE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?' | sed 's/^v//')
+fi
+if [ -n "$MANIFEST_VERSION" ]; then
   if command -v node > /dev/null 2>&1; then
     node -e "
       const fs = require('fs');
       const p = '$EXTENSION_DIR/manifest.json';
       const m = JSON.parse(fs.readFileSync(p, 'utf8'));
-      m.version = '$TAG_VERSION';
+      m.version = '$MANIFEST_VERSION';
       fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
     "
   else
-    sed -i.bak "s/\"version\": *\"[^\"]*\"/\"version\": \"$TAG_VERSION\"/" "$EXTENSION_DIR/manifest.json"
+    sed -i.bak "s/\"version\": *\"[^\"]*\"/\"version\": \"$MANIFEST_VERSION\"/" "$EXTENSION_DIR/manifest.json"
     rm -f "$EXTENSION_DIR/manifest.json.bak"
   fi
-  echo "Manifest version: $TAG_VERSION"
+  echo "Manifest version: $MANIFEST_VERSION"
 fi
 
 # Package extension


### PR DESCRIPTION
## Summary

Fixes #99.

This keeps `extension/manifest.json` aligned with `package.json` when building from `main`, while still using `git describe` for build metadata in `buildinfo.json`.

## Changes

- Read the package version from `package.json` in the cross-platform XPI builder.
- Do the same in the shell build script when Node is available.
- Keep the existing git-tag parsing as a fallback if `package.json` cannot be read.

## Verification

- Ran `node scripts/build-xpi.cjs` locally.
- Verified the generated XPI manifest version is `0.5.1` instead of being downgraded to `0.5.0`.

Note: I intentionally did not include the regenerated `dist/thunderbird-mcp.xpi` in this PR to keep the patch focused on the build logic.