### PR TITLE
feat(calendar): add categories to createEvent, updateEvent, and listEvents

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -272,6 +272,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             calendarId: { type: "string", description: "Target calendar ID (from listCalendars, defaults to first writable calendar)" },
             allDay: { type: "boolean", description: "Create an all-day event (default: false)" },
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
+            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (blocks time, TRANSP:OPAQUE) or 'free' (TRANSP:TRANSPARENT). Defaults to 'busy'." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -309,6 +310,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             location: { type: "string", description: "New event location (optional)" },
             description: { type: "string", description: "New event description (optional)" },
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
+            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (TRANSP:OPAQUE) or 'free' (TRANSP:TRANSPARENT). Pass null to clear." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -2910,7 +2912,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status) {
+            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs) {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
@@ -3004,6 +3006,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   }
                   event.setProperty("STATUS", normalized);
                 }
+                event.setProperty("TRANSP", showAs === "free" ? "TRANSPARENT" : "OPAQUE");
 
                 // Find target calendar
                 const calendars = cal.manager.getCalendars();
@@ -3441,7 +3444,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status) {
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -3512,6 +3515,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     newItem.setProperty("STATUS", normalized);
                   }
                   changes.push("status");
+                }
+                if (showAs !== undefined) {
+                  if (showAs === null || showAs === "") {
+                    newItem.deleteProperty("TRANSP");
+                  } else if (showAs === "free") {
+                    newItem.setProperty("TRANSP", "TRANSPARENT");
+                  } else if (showAs === "busy") {
+                    newItem.setProperty("TRANSP", "OPAQUE");
+                  } else {
+                    return { error: `Invalid showAs: "${showAs}". Expected "busy" or "free".` };
+                  }
+                  changes.push("showAs");
                 }
 
                 if (changes.length === 0) return { error: "No changes specified" };
@@ -5802,11 +5817,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listCalendars":
                   return listCalendars();
                 case "createEvent":
-                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status);
+                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs);
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs);
                 case "deleteEvent":
                   return await deleteEvent(args.eventId, args.calendarId);
                 case "listCategories":

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -272,7 +272,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             calendarId: { type: "string", description: "Target calendar ID (from listCalendars, defaults to first writable calendar)" },
             allDay: { type: "boolean", description: "Create an all-day event (default: false)" },
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
-            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (blocks time, TRANSP:OPAQUE) or 'free' (TRANSP:TRANSPARENT). Defaults to 'busy'." },
+            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid block, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Defaults to 'busy'. Overridden per-property by explicit status parameter." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -310,7 +310,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             location: { type: "string", description: "New event location (optional)" },
             description: { type: "string", description: "New event description (optional)" },
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
-            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (TRANSP:OPAQUE) or 'free' (TRANSP:TRANSPARENT). Pass null to clear." },
+            showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Pass null to clear TRANSP only. Explicit status parameter overrides the STATUS coupling." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -2999,13 +2999,15 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 
                 if (location) event.setProperty("LOCATION", location);
                 if (description) event.setProperty("DESCRIPTION", description);
-                if (status !== undefined && status !== null && status !== "") {
-                  const normalized = normalizeEventStatus(status);
-                  if (!normalized) {
-                    return { error: `Invalid status: "${status}". Expected tentative, confirmed, or cancelled.` };
-                  }
-                  event.setProperty("STATUS", normalized);
+                // STATUS: explicit param wins; otherwise derive from showAs so Thunderbird renders busy=solid, free=hatched
+                const effectiveStatus = (status !== undefined && status !== null && status !== "")
+                  ? status
+                  : (showAs === "free" ? "tentative" : "confirmed");
+                const normalizedStatus = normalizeEventStatus(effectiveStatus);
+                if (!normalizedStatus) {
+                  return { error: `Invalid status: "${effectiveStatus}". Expected tentative, confirmed, or cancelled.` };
                 }
+                event.setProperty("STATUS", normalizedStatus);
                 event.setProperty("TRANSP", showAs === "free" ? "TRANSPARENT" : "OPAQUE");
 
                 // Find target calendar
@@ -3521,8 +3523,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     newItem.deleteProperty("TRANSP");
                   } else if (showAs === "free") {
                     newItem.setProperty("TRANSP", "TRANSPARENT");
+                    // Also set STATUS:TENTATIVE for Thunderbird visual display unless caller overrides
+                    if (status === undefined) { newItem.setProperty("STATUS", "TENTATIVE"); changes.push("status"); }
                   } else if (showAs === "busy") {
                     newItem.setProperty("TRANSP", "OPAQUE");
+                    // Also set STATUS:CONFIRMED for Thunderbird visual display unless caller overrides
+                    if (status === undefined) { newItem.setProperty("STATUS", "CONFIRMED"); changes.push("status"); }
                   } else {
                     return { error: `Invalid showAs: "${showAs}". Expected "busy" or "free".` };
                   }

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -273,6 +273,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             allDay: { type: "boolean", description: "Create an all-day event (default: false)" },
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid block, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Defaults to 'busy'. Overridden per-property by explicit status parameter." },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Use listCategories to get exact existing names before setting." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -311,6 +312,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             description: { type: "string", description: "New event description (optional)" },
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Pass null to clear TRANSP only. Explicit status parameter overrides the STATUS coupling." },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Pass an empty array to clear all categories. Use listCategories to get exact existing names." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -2912,7 +2914,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs) {
+            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs, categories) {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
@@ -3009,6 +3011,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 }
                 event.setProperty("STATUS", normalizedStatus);
                 event.setProperty("TRANSP", showAs === "free" ? "TRANSPARENT" : "OPAQUE");
+                if (categories && categories.length > 0) event.setCategories(categories);
 
                 // Find target calendar
                 const calendars = cal.manager.getCalendars();
@@ -3115,6 +3118,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 // when the event has no explicit status (iCal spec treats this
                 // as implicit -- Thunderbird renders it like confirmed).
                 status: (item.getProperty("STATUS") || "").toLowerCase(),
+                categories: item.getCategories(),
                 allDay,
                 isRecurring: !!item.recurrenceInfo,
               };
@@ -3446,7 +3450,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs) {
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -3533,6 +3537,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     return { error: `Invalid showAs: "${showAs}". Expected "busy" or "free".` };
                   }
                   changes.push("showAs");
+                }
+
+                if (categories !== undefined) {
+                  newItem.setCategories(categories || []);
+                  changes.push("categories");
                 }
 
                 if (changes.length === 0) return { error: "No changes specified" };
@@ -5823,11 +5832,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listCalendars":
                   return listCalendars();
                 case "createEvent":
-                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs);
+                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs, args.categories);
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories);
                 case "deleteEvent":
                   return await deleteEvent(args.eventId, args.calendarId);
                 case "listCategories":


### PR DESCRIPTION
## Summary

- `createEvent` and `updateEvent` now accept an optional `categories` array
- `listEvents` now returns a `categories` field on every event
- Pass an empty array to `updateEvent` to clear all categories
- Use `listCategories` to get exact category names before setting (names are case-sensitive)

## Test plan

- [ ] `createEvent` with `categories: ["Personal"]` → category visible in Thunderbird
- [ ] `createEvent` without `categories` → `categories: []` in `listEvents` response
- [ ] `updateEvent` with new category → reflected in `listEvents`
- [ ] `updateEvent` with `categories: []` → clears all categories
- [ ] `listEvents` returns `categories` array for all events

🤖 Generated with [Claude Code](https://claude.com/claude-code)