### PR TITLE
feat(calendar): add categories to createEvent, updateEvent, and listEvents

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -272,7 +272,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             calendarId: { type: "string", description: "Target calendar ID (from listCalendars, defaults to first writable calendar)" },
             allDay: { type: "boolean", description: "Create an all-day event (default: false)" },
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
-            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Use listCategories to get exact existing names before setting." },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; use listCategories to get exact existing names before setting." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -310,7 +310,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             location: { type: "string", description: "New event location (optional)" },
             description: { type: "string", description: "New event description (optional)" },
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
-            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Pass an empty array to clear all categories. Use listCategories to get exact existing names." },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; pass an empty array to clear all categories. Use listCategories to get exact existing names before setting." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -3544,8 +3544,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   }
                   changes.push("status");
                 }
-                if (categories !== undefined) {
-                  newItem.setCategories(categories || []);
+                // null/undefined preserves existing categories; empty array clears them.
+                if (Array.isArray(categories)) {
+                  newItem.setCategories(categories);
                   changes.push("categories");
                 }
 

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -272,6 +272,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             calendarId: { type: "string", description: "Target calendar ID (from listCalendars, defaults to first writable calendar)" },
             allDay: { type: "boolean", description: "Create an all-day event (default: false)" },
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Use listCategories to get exact existing names before setting." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -309,6 +310,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             location: { type: "string", description: "New event location (optional)" },
             description: { type: "string", description: "New event description (optional)" },
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
+            categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Pass an empty array to clear all categories. Use listCategories to get exact existing names." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -2937,7 +2939,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status) {
+            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, categories) {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
@@ -3031,6 +3033,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   }
                   event.setProperty("STATUS", normalized);
                 }
+                if (categories && categories.length > 0) event.setCategories(categories);
 
                 // Find target calendar
                 const calendars = cal.manager.getCalendars();
@@ -3137,6 +3140,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 // when the event has no explicit status (iCal spec treats this
                 // as implicit -- Thunderbird renders it like confirmed).
                 status: (item.getProperty("STATUS") || "").toLowerCase(),
+                categories: item.getCategories(),
                 allDay,
                 isRecurring: !!item.recurrenceInfo,
               };
@@ -3468,7 +3472,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status) {
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, categories) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -3539,6 +3543,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     newItem.setProperty("STATUS", normalized);
                   }
                   changes.push("status");
+                }
+                if (categories !== undefined) {
+                  newItem.setCategories(categories || []);
+                  changes.push("categories");
                 }
 
                 if (changes.length === 0) return { error: "No changes specified" };
@@ -6290,11 +6298,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listCalendars":
                   return listCalendars();
                 case "createEvent":
-                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status);
+                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.categories);
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.categories);
                 case "deleteEvent":
                   return await deleteEvent(args.eventId, args.calendarId);
                 case "listCategories":

--- a/test/event-categories.test.cjs
+++ b/test/event-categories.test.cjs
@@ -1,0 +1,80 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+function applyUpdateEventCategories(newItem, categories, changes) {
+  if (Array.isArray(categories)) {
+    newItem.setCategories(categories);
+    changes.push("categories");
+  }
+}
+
+function createMockItem(initialCategories = ["Existing"]) {
+  return {
+    categories: initialCategories.slice(),
+    setCategoriesCalls: [],
+    setCategories(categories) {
+      this.setCategoriesCalls.push(categories);
+      this.categories = categories;
+    },
+  };
+}
+
+describe("updateEvent category normalization", () => {
+  it("treats categories: null as no-op", () => {
+    const item = createMockItem();
+    const changes = [];
+
+    applyUpdateEventCategories(item, null, changes);
+
+    assert.deepEqual(item.categories, ["Existing"]);
+    assert.deepEqual(item.setCategoriesCalls, []);
+    assert.deepEqual(changes, []);
+  });
+
+  it("treats categories: undefined as no-op", () => {
+    const item = createMockItem();
+    const changes = [];
+
+    applyUpdateEventCategories(item, undefined, changes);
+
+    assert.deepEqual(item.categories, ["Existing"]);
+    assert.deepEqual(item.setCategoriesCalls, []);
+    assert.deepEqual(changes, []);
+  });
+
+  it("clears all categories with an empty array", () => {
+    const item = createMockItem();
+    const changes = [];
+    const categories = [];
+
+    applyUpdateEventCategories(item, categories, changes);
+
+    assert.deepEqual(item.categories, []);
+    assert.strictEqual(item.setCategoriesCalls[0], categories);
+    assert.deepEqual(changes, ["categories"]);
+  });
+
+  it("sets a multi-item category list", () => {
+    const item = createMockItem();
+    const changes = [];
+    const categories = ["Work", "Personal"];
+
+    applyUpdateEventCategories(item, categories, changes);
+
+    assert.deepEqual(item.categories, ["Work", "Personal"]);
+    assert.strictEqual(item.setCategoriesCalls[0], categories);
+    assert.deepEqual(changes, ["categories"]);
+  });
+
+  it("sets a single-item category list", () => {
+    const item = createMockItem();
+    const changes = [];
+    const categories = ["Work"];
+
+    applyUpdateEventCategories(item, categories, changes);
+
+    assert.deepEqual(item.categories, ["Work"]);
+    assert.strictEqual(item.setCategoriesCalls[0], categories);
+    assert.deepEqual(changes, ["categories"]);
+  });
+});


### PR DESCRIPTION
## Summary

- `createEvent` and `updateEvent` now accept an optional `categories` array
- `listEvents` now returns a `categories` field on every event
- Pass an empty array to `updateEvent` to clear all categories
- Use `listCategories` to get exact category names before setting (names are case-sensitive)

## Merge order note

This PR touches the same lines as PR #105 (`showAs` parameter). If #105 merges first, this branch will need a rebase before it can merge cleanly. The conflicts are trivial — four lines where both PRs extend the same function signatures and dispatch calls:

```js
// After rebasing on the merged main, these become:
async function createEvent(..., status, showAs, categories)
async function updateEvent(..., status, showAs, categories)
return await createEvent(..., args.status, args.showAs, args.categories)
return await updateEvent(..., args.status, args.showAs, args.categories)
```

Happy to rebase once #105 is merged if that helps.

## Test plan

- [ ] `createEvent` with `categories: ["Personal"]` → category visible in Thunderbird
- [ ] `createEvent` without `categories` → `categories: []` in `listEvents` response
- [ ] `updateEvent` with new category → reflected in `listEvents`
- [ ] `updateEvent` with `categories: []` → clears all categories
- [ ] `listEvents` returns `categories` array for all events

🤖 Generated with [Claude Code](https://claude.com/claude-code)