### PR TITLE
feat(calendar): add onlineMeeting param to createEvent and updateEvent

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -328,6 +328,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid block, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Defaults to 'busy'. Overridden per-property by explicit status parameter." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; use listCategories to get exact existing names before setting." },
+            onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). The join URL is returned in the response and embedded in the event description." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],
@@ -367,6 +368,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             status: { type: "string", description: "New VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled' (optional)" },
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Pass null to clear TRANSP only. Explicit status parameter overrides the STATUS coupling." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; pass an empty array to clear all categories. Use listCategories to get exact existing names before setting." },
+            onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). Pass false to remove an existing Teams link." },
           },
           required: ["eventId", "calendarId"],
         },
@@ -2998,7 +3000,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs, categories) {
+            async function createEvent(title, startDate, endDate, location, description, calendarId, allDay, skipReview, status, showAs, categories, onlineMeeting) {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
@@ -3099,6 +3101,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 event.setProperty("STATUS", normalizedStatus);
                 event.setProperty("TRANSP", showAs === "free" ? "TRANSPARENT" : "OPAQUE");
                 if (categories && categories.length > 0) event.setCategories(categories);
+                if (onlineMeeting) event.setProperty("X-ONLINE-MEETING-PROVIDER", "TeamsForBusiness");
 
                 // Find target calendar
                 const calendars = cal.manager.getCalendars();
@@ -3206,6 +3209,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 // as implicit -- Thunderbird renders it like confirmed).
                 status: (item.getProperty("STATUS") || "").toLowerCase(),
                 categories: item.getCategories(),
+                onlineMeetingURL: item.getProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL") || null,
                 allDay,
                 isRecurring: !!item.recurrenceInfo,
               };
@@ -3537,7 +3541,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
-            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories) {
+            async function updateEvent(eventId, calendarId, title, startDate, endDate, location, description, status, showAs, categories, onlineMeeting) {
               if (!cal) return { error: "Calendar not available" };
               try {
                 if (!eventId) return { error: "eventId is required" };
@@ -3629,6 +3633,15 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 if (Array.isArray(categories)) {
                   newItem.setCategories(categories);
                   changes.push("categories");
+                }
+                if (onlineMeeting !== undefined) {
+                  if (onlineMeeting) {
+                    newItem.setProperty("X-ONLINE-MEETING-PROVIDER", "TeamsForBusiness");
+                  } else {
+                    newItem.deleteProperty("X-ONLINE-MEETING-PROVIDER");
+                    newItem.deleteProperty("X-MICROSOFT-SKYPETEAMSMEETINGURL");
+                  }
+                  changes.push("onlineMeeting");
                 }
 
                 if (changes.length === 0) return { error: "No changes specified" };
@@ -6444,11 +6457,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listCalendars":
                   return listCalendars();
                 case "createEvent":
-                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs, args.categories);
+                  return await createEvent(args.title, args.startDate, args.endDate, args.location, args.description, args.calendarId, args.allDay, args.skipReview, args.status, args.showAs, args.categories, args.onlineMeeting);
                 case "listEvents":
                   return await listEvents(args.calendarId, args.startDate, args.endDate, args.maxResults);
                 case "updateEvent":
-                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories);
+                  return await updateEvent(args.eventId, args.calendarId, args.title, args.startDate, args.endDate, args.location, args.description, args.status, args.showAs, args.categories, args.onlineMeeting);
                 case "deleteEvent":
                   return await deleteEvent(args.eventId, args.calendarId);
                 case "listCategories":

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -328,7 +328,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             status: { type: "string", description: "VEVENT STATUS: 'tentative', 'confirmed', or 'cancelled'. Defaults to confirmed if omitted." },
             showAs: { type: "string", enum: ["busy", "free"], description: "How the event appears in the calendar: 'busy' (solid block, TRANSP:OPAQUE + STATUS:CONFIRMED) or 'free' (hatched, TRANSP:TRANSPARENT + STATUS:TENTATIVE). Defaults to 'busy'. Overridden per-property by explicit status parameter." },
             categories: { type: "array", items: { type: "string" }, description: "Category labels (optional). Category names are case-sensitive; use listCategories to get exact existing names before setting." },
-            onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). The join URL is returned in the response and embedded in the event description." },
+            onlineMeeting: { type: "boolean", description: "If true, generates a Microsoft Teams meeting link via Exchange (OWL/Office 365 accounts only). After creation, OWL embeds the join URL in the event description and exposes it via listEvents (onlineMeetingURL). No-op on non-OWL backends." },
             skipReview: { type: "boolean", description: "If true, add the event directly without opening a review dialog (default: false)" },
           },
           required: ["title", "startDate"],

--- a/test/event-online-meeting.test.cjs
+++ b/test/event-online-meeting.test.cjs
@@ -1,0 +1,117 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const PROVIDER_PROPERTY = "X-ONLINE-MEETING-PROVIDER";
+const TEAMS_URL_PROPERTY = "X-MICROSOFT-SKYPETEAMSMEETINGURL";
+
+// Mirrors updateEvent's onlineMeeting decision tree. XPCOM is unavailable in
+// node:test, so this covers only the property mutation rules.
+function applyUpdateOnlineMeeting(newItem, onlineMeeting, changes) {
+  if (onlineMeeting !== undefined) {
+    if (onlineMeeting) {
+      newItem.setProperty(PROVIDER_PROPERTY, "TeamsForBusiness");
+    } else {
+      newItem.deleteProperty(PROVIDER_PROPERTY);
+      newItem.deleteProperty(TEAMS_URL_PROPERTY);
+    }
+    changes.push("onlineMeeting");
+  }
+}
+
+function formatOnlineMeetingURL(item) {
+  return item.getProperty(TEAMS_URL_PROPERTY) || null;
+}
+
+function createMockItem(initialProperties = {}) {
+  return {
+    properties: new Map(Object.entries(initialProperties)),
+    setPropertyCalls: [],
+    deletePropertyCalls: [],
+    getProperty(name) {
+      return this.properties.get(name);
+    },
+    setProperty(name, value) {
+      this.setPropertyCalls.push([name, value]);
+      this.properties.set(name, value);
+    },
+    deleteProperty(name) {
+      this.deletePropertyCalls.push(name);
+      this.properties.delete(name);
+    },
+  };
+}
+
+describe("updateEvent onlineMeeting decision tree", () => {
+  it("true requests Teams meeting generation", () => {
+    const item = createMockItem();
+    const changes = [];
+
+    applyUpdateOnlineMeeting(item, true, changes);
+
+    assert.deepEqual(item.setPropertyCalls, [[PROVIDER_PROPERTY, "TeamsForBusiness"]]);
+    assert.deepEqual(item.deletePropertyCalls, []);
+    assert.deepEqual(changes, ["onlineMeeting"]);
+  });
+
+  it("false removes Teams meeting properties", () => {
+    const item = createMockItem({
+      [PROVIDER_PROPERTY]: "TeamsForBusiness",
+      [TEAMS_URL_PROPERTY]: "https://teams.example/join",
+    });
+    const changes = [];
+
+    applyUpdateOnlineMeeting(item, false, changes);
+
+    assert.equal(item.getProperty(PROVIDER_PROPERTY), undefined);
+    assert.equal(item.getProperty(TEAMS_URL_PROPERTY), undefined);
+    assert.deepEqual(item.deletePropertyCalls, [PROVIDER_PROPERTY, TEAMS_URL_PROPERTY]);
+    assert.deepEqual(changes, ["onlineMeeting"]);
+  });
+
+  it("undefined is no-op", () => {
+    const item = createMockItem({
+      [PROVIDER_PROPERTY]: "TeamsForBusiness",
+      [TEAMS_URL_PROPERTY]: "https://teams.example/join",
+    });
+    const changes = [];
+
+    applyUpdateOnlineMeeting(item, undefined, changes);
+
+    assert.equal(item.getProperty(PROVIDER_PROPERTY), "TeamsForBusiness");
+    assert.equal(item.getProperty(TEAMS_URL_PROPERTY), "https://teams.example/join");
+    assert.deepEqual(item.setPropertyCalls, []);
+    assert.deepEqual(item.deletePropertyCalls, []);
+    assert.deepEqual(changes, []);
+  });
+
+  it("null removes Teams meeting properties", () => {
+    const item = createMockItem({
+      [PROVIDER_PROPERTY]: "TeamsForBusiness",
+      [TEAMS_URL_PROPERTY]: "https://teams.example/join",
+    });
+    const changes = [];
+
+    applyUpdateOnlineMeeting(item, null, changes);
+
+    assert.equal(item.getProperty(PROVIDER_PROPERTY), undefined);
+    assert.equal(item.getProperty(TEAMS_URL_PROPERTY), undefined);
+    assert.deepEqual(item.deletePropertyCalls, [PROVIDER_PROPERTY, TEAMS_URL_PROPERTY]);
+    assert.deepEqual(changes, ["onlineMeeting"]);
+  });
+});
+
+describe("formatEvent onlineMeetingURL mapping", () => {
+  it("maps the Teams meeting URL property", () => {
+    const item = createMockItem({
+      [TEAMS_URL_PROPERTY]: "https://teams.example/join",
+    });
+
+    assert.equal(formatOnlineMeetingURL(item), "https://teams.example/join");
+  });
+
+  it("returns null when the Teams meeting URL property is missing", () => {
+    assert.equal(formatOnlineMeetingURL(createMockItem()), null);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an optional `onlineMeeting` boolean parameter to `createEvent` and `updateEvent`
- When `true`, sets `X-ONLINE-MEETING-PROVIDER: TeamsForBusiness` on the iCal event
- OWL (Owl for Exchange) reads this property via `Event2JSON` and routes to `CreateTeamsMeeting()` in its OWA backend, which asks Exchange/Office 365 to generate a Teams join URL server-side
- The join URL is written back immediately to `X-MICROSOFT-SKYPETEAMSMEETINGURL` and surfaced as `onlineMeetingURL` in `listEvents` responses
- `updateEvent` with `onlineMeeting: false` removes an existing Teams link
- Defaults to `false` — no Teams link is created unless explicitly requested

## Notes

This feature currently works only with OWL/Office 365 Exchange accounts. The `X-ONLINE-MEETING-PROVIDER` property is OWL-specific; other calendar backends (CalDAV, Google) will silently ignore it. In principle the approach could be extended to other providers — for example, Google Meet links could be requested via the Google Calendar API using `conferenceData.createRequest` — but that would require provider-specific handling beyond the scope of this PR.

I considered not submitting this upstream for that reason, but thought it worth leaving to the maintainer's discretion — it adds no overhead for non-OWL users and may be useful for others on Exchange.

## Test plan

- [ ] `createEvent` with `onlineMeeting: true` → event appears in Thunderbird with Teams join link in description and location
- [ ] `listEvents` response includes `onlineMeetingURL` field populated with the join URL
- [ ] `createEvent` without `onlineMeeting` → no Teams link added (default behaviour unchanged)
- [ ] `updateEvent` with `onlineMeeting: true` on existing event → Teams link added
- [ ] `updateEvent` with `onlineMeeting: false` on event with Teams link → link removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)