### PR TITLE
fix: bump strict_max_version to 151.* for Thunderbird 151 compatibility

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,7 @@
     "gecko": {
       "id": "thunderbird-mcp@tkasperczyk.dev",
       "strict_min_version": "102.0",
-      "strict_max_version": "150.*"
+      "strict_max_version": "151.*"
     }
   },
   "icons": {


### PR DESCRIPTION
## Summary

Thunderbird 151.0 was released and the extension's `strict_max_version` cap of `150.*` in `manifest.json` causes it to be automatically disabled, leaving users with no way to enable it.

- Bumps `strict_max_version` from `150.*` to `151.*` in `extension/manifest.json`

## Steps to reproduce

1. Install or update to Thunderbird 151.0
2. Open Add-ons Manager — extension shows as disabled with warning "Thunderbird MCP is not compatible with Thunderbird 151.0"

## Fix

One-line change in `extension/manifest.json`:

```diff
-      "strict_max_version": "150.*"
+      "strict_max_version": "151.*"
```

Tested locally on Thunderbird 151.0 — extension loads and the MCP bridge connects successfully after rebuilding the XPI.