### PR TITLE
perf: compact MCP tool result JSON

### DIFF
--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -700,6 +700,25 @@ function tryAllHosts(hosts, postData, port, token) {
   return tryNext(hosts);
 }
 
+function compactToolResultJsonText(response) {
+  const content = response?.result?.content;
+  if (!Array.isArray(content)) {
+    return response;
+  }
+
+  for (const item of content) {
+    if (item?.type !== 'text' || typeof item.text !== 'string') {
+      continue;
+    }
+    try {
+      item.text = JSON.stringify(JSON.parse(item.text));
+    } catch {
+      // Non-JSON text content is already the compact representation.
+    }
+  }
+  return response;
+}
+
 async function forwardToThunderbird(message) {
   const postData = JSON.stringify(message);
 
@@ -809,7 +828,7 @@ function startBridge() {
     handleMessage(line)
       .then(async (response) => {
         if (response !== null) {
-          await writeOutput(JSON.stringify(response) + '\n');
+          await writeOutput(JSON.stringify(compactToolResultJsonText(response)) + '\n');
           debugLog(`send id=${messageId} method=${messageMethod}`);
         }
       })
@@ -873,6 +892,7 @@ module.exports = {
   findMacOsConnectionCandidates,
   findSnapConnectionCandidates,
   formatDiscoveryAttempts,
+  compactToolResultJsonText,
   isValidAuthToken,
   readConnectionInfo,
   startBridge,

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -706,17 +706,28 @@ function compactToolResultJsonText(response) {
     return response;
   }
 
-  for (const item of content) {
+  let changed = false;
+  const compactedContent = content.map((item) => {
     if (item?.type !== 'text' || typeof item.text !== 'string') {
-      continue;
+      return item;
     }
     try {
-      item.text = JSON.stringify(JSON.parse(item.text));
+      const compactedText = JSON.stringify(JSON.parse(item.text));
+      if (compactedText === item.text) {
+        return item;
+      }
+      changed = true;
+      return { ...item, text: compactedText };
     } catch {
       // Non-JSON text content is already the compact representation.
+      return item;
     }
+  });
+
+  if (!changed) {
+    return response;
   }
-  return response;
+  return { ...response, result: { ...response.result, content: compactedContent } };
 }
 
 async function forwardToThunderbird(message) {

--- a/test/mcp-bridge.test.cjs
+++ b/test/mcp-bridge.test.cjs
@@ -104,24 +104,27 @@ describe('Auth token validation', () => {
 });
 
 describe('Tool result serialization', () => {
-  it('compacts JSON text content without changing the parsed value', () => {
+  it('compacts JSON text content without mutating the original response', () => {
+    const originalText = JSON.stringify([{ name: 'INBOX', unreadMessages: 3 }], null, 2);
     const response = {
       jsonrpc: '2.0',
       id: 2,
       result: {
         content: [{
           type: 'text',
-          text: JSON.stringify([{ name: 'INBOX', unreadMessages: 3 }], null, 2),
+          text: originalText,
         }],
       },
     };
 
     const compacted = compactToolResultJsonText(response);
 
+    assert.notStrictEqual(compacted, response);
     assert.deepStrictEqual(
       JSON.parse(compacted.result.content[0].text),
-      JSON.parse(response.result.content[0].text)
+      JSON.parse(originalText)
     );
+    assert.equal(response.result.content[0].text, originalText);
     assert.equal(compacted.result.content[0].text.includes('\n'), false);
   });
 });

--- a/test/mcp-bridge.test.cjs
+++ b/test/mcp-bridge.test.cjs
@@ -7,6 +7,7 @@ const path = require('path');
 const {
   advanceToNextCandidate,
   buildConnectionDiscoveryErrorMessage,
+  compactToolResultJsonText,
   clearConnectionCache,
   discoverConnectionInfo,
   isValidAuthToken,
@@ -99,6 +100,29 @@ describe('Auth token validation', () => {
     assert.equal(isValidAuthToken('g'.repeat(64)), false);
     assert.equal(isValidAuthToken(`${'a'.repeat(64)}\n`), false);
     assert.equal(isValidAuthToken(null), false);
+  });
+});
+
+describe('Tool result serialization', () => {
+  it('compacts JSON text content without changing the parsed value', () => {
+    const response = {
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        content: [{
+          type: 'text',
+          text: JSON.stringify([{ name: 'INBOX', unreadMessages: 3 }], null, 2),
+        }],
+      },
+    };
+
+    const compacted = compactToolResultJsonText(response);
+
+    assert.deepStrictEqual(
+      JSON.parse(compacted.result.content[0].text),
+      JSON.parse(response.result.content[0].text)
+    );
+    assert.equal(compacted.result.content[0].text.includes('\n'), false);
   });
 });
 


### PR DESCRIPTION
# Compact MCP Tool Result JSON

## What changed

- Compact JSON strings inside MCP `tools/call` text payloads before the bridge writes
  responses to stdout.
- Preserve the parsed tool result exactly; this only removes JSON formatting whitespace.
- Add a bridge unit test covering compaction without changing the parsed value.

## Why

The Thunderbird extension currently returns tool results as pretty-printed JSON text. That
format is easier for humans to read, but expensive for model context. The bridge already
serializes the outer JSON-RPC response compactly, so this change compacts the inner tool
result text as well.

## Measurement

Measured by calling the local Thunderbird MCP server through `mcp-bridge.cjs` from Node,
capturing before/after JSON-RPC responses, and comparing response bytes plus text payload
characters. Mutating tools were not called.

| label | beforeBytes | afterBytes | savedBytes | savedPercent | beforeTextPayloadChars | afterTextPayloadChars | savedTextPayloadChars | roughTokensSaved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| initialize | 152 | 152 | 0 | 0.0 | 0 | 0 | 0 | 0 |
| tools-list | 30477 | 30477 | 0 | 0.0 | 0 | 0 | 0 | 0 |
| resources-list | 50 | 50 | 0 | 0.0 | 0 | 0 | 0 | 0 |
| prompts-list | 48 | 48 | 0 | 0.0 | 0 | 0 | 0 | 0 |
| tool-getAccountAccess | 1985 | 1345 | 640 | 32.2 | 1630 | 1074 | 556 | 139 |
| tool-listAccounts | 4524 | 2956 | 1568 | 34.7 | 3815 | 2449 | 1366 | 342 |
| tool-listFolders | 37282 | 28958 | 8324 | 22.3 | 32682 | 25673 | 7009 | 1752 |
| tool-getRecentMessages | 2674 | 2282 | 392 | 14.7 | 2352 | 2021 | 331 | 83 |
| tool-searchMessages | 3049 | 2622 | 427 | 14.0 | 2686 | 2325 | 361 | 90 |
| tool-searchContacts | 1818 | 1422 | 396 | 21.8 | 1546 | 1200 | 346 | 87 |
| tool-listCalendars | 2183 | 1681 | 502 | 23.0 | 1848 | 1427 | 421 | 105 |
| tool-listCategories | 455 | 365 | 90 | 19.8 | 314 | 247 | 67 | 17 |
| tool-listEvents | 10904 | 9062 | 1842 | 16.9 | 9669 | 8108 | 1561 | 390 |
| tool-listTasks | 76 | 76 | 0 | 0.0 | 2 | 2 | 0 | 0 |
| tool-listFilters | 4091 | 2808 | 1283 | 31.4 | 3540 | 2416 | 1124 | 281 |

Totals:

```text
before bytes: 99,768
after bytes:  84,304
saved bytes:  15,464
saved:        15.5%

tool text payload chars saved: 13,142
rough tokens saved:           3,286
```

## Verification

```text
node --test test/mcp-bridge.test.cjs
```

The full `node --test test/*.test.cjs` was also attempted, but existing auth/network-style
tests failed in the local environment, so only the targeted bridge test is treated as
passing evidence for this change.

## Examples

Before, a `tools/call` response embedded a pretty-printed JSON string inside the MCP text
content:

```json
{
  "jsonrpc": "2.0",
  "id": 7,
  "result": {
    "content": [
      {
        "type": "text",
        "text": "[\n  {\n    \"name\": \"INBOX\",\n    \"path\": \"imap://user%40example.com@imap.example.com/INBOX\",\n    \"type\": \"inbox\",\n    \"accountId\": \"account1\",\n    \"totalMessages\": 5604,\n    \"unreadMessages\": 183,\n    \"depth\": 0\n  }\n]"
      }
    ]
  }
}
```

After, the outer JSON-RPC response is unchanged, but the embedded JSON text is compact:

```json
{
  "jsonrpc": "2.0",
  "id": 7,
  "result": {
    "content": [
      {
        "type": "text",
        "text": "[{\"name\":\"INBOX\",\"path\":\"imap://user%40example.com@imap.example.com/INBOX\",\"type\":\"inbox\",\"accountId\":\"account1\",\"totalMessages\":5604,\"unreadMessages\":183,\"depth\":0}]"
      }
    ]
  }
}
```
