### PR TITLE
test(mcp-bridge): make macOS uid-scan test platform-independent (passes on Windows)

### DIFF
--- a/test/mcp-bridge.test.cjs
+++ b/test/mcp-bridge.test.cjs
@@ -254,7 +254,11 @@ describe('Bridge discovery', () => {
   });
 
   it('macOS scan finds current uid files and ignores other owners', () => {
-    const currentUid = typeof process.getuid === 'function' ? process.getuid() : 1000;
+    // Pin a synthetic uid rather than process.getuid(). On Windows the real
+    // fs.statSync reports uid=0 for every file regardless of the caller, so we
+    // can't rely on stat.uid matching process.getuid() — both files are stat-
+    // overridden below so the uid-filter logic is exercised on any platform.
+    const currentUid = 1000;
     const darwinRoot = path.join(root, 'var', 'folders');
     const options = makeTestOptions(root, {
       platform: 'darwin',
@@ -275,6 +279,10 @@ describe('Bridge discovery', () => {
     });
 
     const statOverrides = new Map();
+    // Force both stat results: the owned file to the caller's uid and the
+    // foreign one to a different uid, so the filter is tested independent of
+    // what the host's real fs.statSync returns.
+    statOverrides.set(ownedConnFile, { uid: currentUid });
     statOverrides.set(foreignConnFile, { uid: currentUid + 1 });
 
     const connInfo = readConnectionInfo({


### PR DESCRIPTION
Independent, test-only portability fix (no production change). The `Bridge discovery > macOS scan finds current uid files and ignores other owners` test fails on Windows because `fs.statSync` reports `uid=0` for every file there regardless of the caller, so the test's reliance on `stat.uid === process.getuid()` never holds off-POSIX.

Fix: pin a synthetic `currentUid` and `stat`-override **both** the owned and foreign connection files, so the uid-filter logic is exercised on any host platform instead of only POSIX ones.

With this, `node --test test/*.test.cjs` is **0 failures on Windows** (341 pass / 17 skipped) — was 1 failure. Linux/macOS behaviour is unchanged. Useful if CI runs `windows-latest`.
