### PR TITLE
fix(OP_MAP): correct nsMsgSearchOp constants for matches, isInAB and related operators

### DIFF
--- a/docs/filter-api-research.md
+++ b/docs/filter-api-research.md
@@ -517,8 +517,11 @@ function createFilter(accountId, name, enabled, type, conditions, actions, inser
   const OP_MAP = {
     contains: 0, doesntContain: 1, is: 2, isnt: 3, isEmpty: 4,
     isBefore: 5, isAfter: 6, isHigherThan: 7, isLowerThan: 8,
-    beginsWith: 9, endsWith: 10, isInAB: 11, isntInAB: 12,
-    isGreaterThan: 13, isLessThan: 14, matches: 15, doesntMatch: 16,
+    beginsWith: 9, endsWith: 10,
+    soundsLike: 11, ldapDwim: 12,
+    isGreaterThan: 13, isLessThan: 14,
+    nameCompletion: 15, isInAB: 16, isntInAB: 17, isntEmpty: 18,
+    matches: 19, doesntMatch: 20,
   };
 
   for (const cond of conditions) {

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -5878,8 +5878,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             const OP_MAP = {
               contains: 0, doesntContain: 1, is: 2, isnt: 3, isEmpty: 4,
               isBefore: 5, isAfter: 6, isHigherThan: 7, isLowerThan: 8,
-              beginsWith: 9, endsWith: 10, isInAB: 11, isntInAB: 12,
-              isGreaterThan: 13, isLessThan: 14, matches: 15, doesntMatch: 16,
+              beginsWith: 9, endsWith: 10,
+              soundsLike: 11, ldapDwim: 12,
+              isGreaterThan: 13, isLessThan: 14,
+              nameCompletion: 15, isInAB: 16, isntInAB: 17, isntEmpty: 18,
+              matches: 19, doesntMatch: 20,
             };
             const OP_NAMES = Object.fromEntries(Object.entries(OP_MAP).map(([k, v]) => [v, k]));
 


### PR DESCRIPTION
# The problem
OP_MAP in api.js had operators numbered sequentially instead of being derived from the operators' true mapped values.

Source: https://searchfox.org/comm-central/source/mailnews/search/public/nsMsgSearchCore.idl

# How I found the problem: 

Using the MCP server with Betterbird to create filters I found that `matches` (currently mapped to 15), was incorrectly mapped and resulted in a filter with the drop down operator `nameCompletion` (15 is NameCompletion per the IDL). While defined in Thunderbird source code, `matches` and `doesntMatch`, are not used but they are in Betterbird which pulls from the same IDL. See: https://github.com/Betterbird/thunderbird-patches/issues/164.

# The fix: 
Correct constants for the entirety of OP_MAP from 11 and onward, matching the IDL exactly.
Tested on: Betterbird 140.

## Before:
```
const OP_MAP = {
              contains: 0, doesntContain: 1, is: 2, isnt: 3, isEmpty: 4,
              isBefore: 5, isAfter: 6, isHigherThan: 7, isLowerThan: 8,
              beginsWith: 9, endsWith: 10, isInAB: 11, isntInAB: 12,
              isGreaterThan: 13, isLessThan: 14, matches: 15, doesntMatch: 16,
            };
```
## After:
```
const OP_MAP = {
                contains: 0, doesntContain: 1, is: 2, isnt: 3, isEmpty: 4,
                isBefore: 5, isAfter: 6, isHigherThan: 7, isLowerThan: 8,
                beginsWith: 9, endsWith: 10,
                soundsLike: 11, ldapDwim: 12,
                isGreaterThan: 13, isLessThan: 14,
                nameCompletion: 15, isInAB: 16, isntInAB: 17, isntEmpty: 18,
                matches: 19, doesntMatch: 20,
              };
```

## Note:
I understand this MCP is for Thunderbird and not Betterbird but all this change does is further align the Thunderbird-MCP with the source mappings. It is not Betterbird specific.
