### PR TITLE
feat(listFolders): opt-in table format; log skipped folder subtrees

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -153,6 +153,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
           properties: {
             accountId: { type: "string", description: "Optional account ID (from listAccounts) to limit results to a single account" },
             folderPath: { type: "string", description: "Optional folder URI (from listFolders) to list only that folder and its subfolders" },
+            format: { type: "string", enum: ["objects", "table"], description: "Response format: 'objects' (default, existing array of folder objects) or 'table' ({ columns, rows } compact form)" },
           },
           required: [],
         },
@@ -1243,6 +1244,28 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               return result;
             }
 
+            /**
+             * Best-effort refresh for IMAP folders. updateFolder starts async work
+             * and may not complete before callers read from Thunderbird's cache.
+             */
+            function refreshImapFolderSync(folder) {
+              if (folder.server && folder.server.type === "imap") {
+                try {
+                  folder.updateFolder(null);
+                } catch {
+                  // updateFolder may fail, continue anyway
+                }
+              }
+            }
+
+            function toColumnarTable(items, keys) {
+              const columns = Array.from(keys).sort();
+              return {
+                columns,
+                rows: items.map(item => columns.map(column => item[column])),
+              };
+            }
+
             function listAccounts() {
               const accounts = [];
               for (const account of getAccessibleAccounts()) {
@@ -1292,8 +1315,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
              * Lists all folders (optionally limited to a single account).
              * Depth is 0 for root children, increasing for subfolders.
              */
-            function listFolders(accountId, folderPath) {
+            function listFolders(accountId, folderPath, format) {
               const results = [];
+              const outputFormat = format == null ? "objects" : format;
+              const folderKeys = ["name", "path", "type", "accountId", "totalMessages", "unreadMessages", "depth"];
+
+              if (outputFormat !== "objects" && outputFormat !== "table") {
+                return { error: `Invalid format: "${outputFormat}". Must be one of: objects, table` };
+              }
+
+              function formatFolderResults() {
+                return outputFormat === "table" ? toColumnarTable(results, folderKeys) : results;
+              }
 
               function folderType(flags) {
                 if (flags & 0x00001000) return "inbox";
@@ -1322,8 +1355,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     unreadMessages: folder.getNumUnread(false),
                     depth
                   });
-                } catch {
-                  // Skip inaccessible folders
+                } catch (e) {
+                  console.warn("thunderbird-mcp: listFolders skipped inaccessible folder", folder?.URI || folder?.name, e);
                 }
 
                 try {
@@ -1332,8 +1365,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       walkFolder(subfolder, accountKey, depth + 1);
                     }
                   }
-                } catch {
-                  // Skip subfolder traversal errors
+                } catch (e) {
+                  console.warn("thunderbird-mcp: listFolders subfolder traversal failed for folder", folder?.URI || folder?.name, e);
                 }
               }
 
@@ -1346,7 +1379,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   ? (MailServices.accounts.findAccountForServer(folder.server)?.key || "unknown")
                   : "unknown";
                 walkFolder(folder, accountKey, 0);
-                return results;
+                return formatFolderResults();
               }
 
               if (accountId) {
@@ -1370,10 +1403,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       walkFolder(subfolder, target.key, 0);
                     }
                   }
-                } catch {
-                  // Skip inaccessible account
+                } catch (e) {
+                  console.warn("thunderbird-mcp: listFolders failed to enumerate account root", target.key || accountId, e);
                 }
-                return results;
+                return formatFolderResults();
               }
 
               for (const account of getAccessibleAccounts()) {
@@ -1385,12 +1418,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       walkFolder(subfolder, account.key, 0);
                     }
                   }
-                } catch {
-                  // Skip inaccessible accounts/folders
+                } catch (e) {
+                  console.warn("thunderbird-mcp: listFolders failed to enumerate account", account?.key, e);
                 }
               }
 
-              return results;
+              return formatFolderResults();
             }
 
             /**
@@ -2429,15 +2462,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 	                if (result.error) return result;
 	                const folder = result.folder;
 
-	                // Attempt to refresh IMAP folders. This is async and may not
-	                // complete before we read, but helps with stale data.
-	                if (folder.server && folder.server.type === "imap") {
-	                  try {
-	                    folder.updateFolder(null);
-	                  } catch {
-	                    // updateFolder may fail, continue anyway
-	                  }
-	                }
+	                refreshImapFolderSync(folder);
 
 	                const db = folder.msgDatabase;
 	                if (!db) {
@@ -2681,15 +2706,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 if (results.length >= SEARCH_COLLECTION_CAP) return;
 
                 try {
-                  // Attempt to refresh IMAP folders. This is async and may not
-                  // complete before we read, but helps with stale data.
-                  if (folder.server && folder.server.type === "imap") {
-                    try {
-                      folder.updateFolder(null);
-                    } catch {
-                      // updateFolder may fail, continue anyway
-                    }
-                  }
+                  refreshImapFolderSync(folder);
 
                   const db = folder.msgDatabase;
                   if (!db) return;
@@ -6423,7 +6440,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "listAccounts":
                   return listAccounts();
                 case "listFolders":
-                  return listFolders(args.accountId, args.folderPath);
+                  return listFolders(args.accountId, args.folderPath, args.format);
                 case "searchMessages":
                   return await searchMessages(args.query || "", args.folderPath, args.startDate, args.endDate, args.maxResults, args.offset, args.sortOrder, args.unreadOnly, args.flaggedOnly, args.tag, args.includeSubfolders, args.countOnly, args.searchBody);
                 case "getMessage":

--- a/test/list-folders-table.test.cjs
+++ b/test/list-folders-table.test.cjs
@@ -1,0 +1,96 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+// Mirrors the pure listFolders table formatting logic from api.js. The
+// production module runs in Thunderbird/XPCOM and cannot be required directly.
+const FOLDER_KEYS = ["name", "path", "type", "accountId", "totalMessages", "unreadMessages", "depth"];
+
+function toColumnarTable(items, keys) {
+  const columns = Array.from(keys).sort();
+  return {
+    columns,
+    rows: items.map(item => columns.map(column => item[column])),
+  };
+}
+
+function formatFolderResults(results, format) {
+  const outputFormat = format == null ? "objects" : format;
+  if (outputFormat !== "objects" && outputFormat !== "table") {
+    return { error: `Invalid format: "${outputFormat}". Must be one of: objects, table` };
+  }
+  return outputFormat === "table" ? toColumnarTable(results, FOLDER_KEYS) : results;
+}
+
+describe("listFolders table format", () => {
+  const folders = [
+    {
+      name: "INBOX",
+      path: "imap://user@example.com/INBOX",
+      type: "inbox",
+      accountId: "account1",
+      totalMessages: 42,
+      unreadMessages: 3,
+      depth: 0,
+    },
+    {
+      name: "Projects",
+      path: "imap://user@example.com/INBOX/Projects",
+      type: "folder",
+      accountId: "account1",
+      totalMessages: 7,
+      unreadMessages: 1,
+      depth: 1,
+    },
+  ];
+
+  it("returns the existing array unchanged when format is omitted, null, or objects", () => {
+    assert.strictEqual(formatFolderResults(folders, undefined), folders);
+    assert.strictEqual(formatFolderResults(folders, null), folders);
+    assert.strictEqual(formatFolderResults(folders, "objects"), folders);
+  });
+
+  it("returns the table shape when requested", () => {
+    const result = formatFolderResults(folders, "table");
+    assert.deepStrictEqual(Object.keys(result), ["columns", "rows"]);
+    assert.equal(result.rows.length, 2);
+  });
+
+  it("sorts columns alphabetically from the stable folder key set", () => {
+    const result = formatFolderResults(folders, "table");
+    assert.deepStrictEqual(result.columns, [
+      "accountId",
+      "depth",
+      "name",
+      "path",
+      "totalMessages",
+      "type",
+      "unreadMessages",
+    ]);
+  });
+
+  it("orders row values to match the columns", () => {
+    const result = formatFolderResults(folders, "table");
+    assert.deepStrictEqual(result.rows[0], result.columns.map(column => folders[0][column]));
+    assert.deepStrictEqual(result.rows[1], result.columns.map(column => folders[1][column]));
+  });
+
+  it("keeps stable columns for an empty table", () => {
+    const result = formatFolderResults([], "table");
+    assert.deepStrictEqual(result.columns, [
+      "accountId",
+      "depth",
+      "name",
+      "path",
+      "totalMessages",
+      "type",
+      "unreadMessages",
+    ]);
+    assert.deepStrictEqual(result.rows, []);
+  });
+
+  it("rejects unknown format values", () => {
+    assert.deepStrictEqual(formatFolderResults(folders, "compact"), {
+      error: 'Invalid format: "compact". Must be one of: objects, table',
+    });
+  });
+});


### PR DESCRIPTION
Originally bundled an IMAP-refresh attempt at #133; research into comm-central showed `updateFolder` does **not** discover server-side subfolders (it runs a SELECT to sync a folder's own messages, not a LIST of its children -- discovery is a separate async `performExpand` -> `DiscoverChildren` path). So that refresh was dropped from `listFolders`. What remains is the clean, useful part:

## Opt-in compact `format: "table"` (#121, listFolders slice)
- New optional `format` enum `["objects","table"]`, default `"objects"`. Validated in the handler (the generic validator doesn't enforce enums); unknown values return a clear `{error}`.
- `format: "table"` returns `{ columns: [sorted keys], rows: [[values]] }` to cut token usage on large folder lists. Default returns the existing object array unchanged -- no break for existing callers.
- First slice of the broader #121 discussion (listFolders has the clearest, fully-stable column set); other list tools can follow.

## Diagnostics in the folder walk
- The four silent `catch {}` blocks in the `listFolders` traversal now `console.warn` the folder URI + error and continue, so a skipped or failing subtree is logged instead of vanishing -- useful when debugging reports like #133.

## Small refactor
- Extracted `refreshImapFolderSync` (best-effort `updateFolder(null)`, IMAP-guarded) and routed `openFolder` and `searchMessages` through it; that message-refresh block was duplicated inline in both. (This is `updateFolder`'s correct use -- syncing a folder's own messages before reading them.)

## On #133 (not fixed here)
`updateFolder` can't surface missing subfolders, and the reporter's symptom (folders manually opened, persists across restart, some accounts partial) points at subscription / "Show only subscribed folders" rather than staleness -- which no refresh fixes. The remedy is the Subscribe/Repair steps already given on #133. Proper programmatic discovery would need `performExpand` + an async `listFolders` awaiting a folder/url listener; that's a separate feature, not this PR.

## Test plan
- `test/list-folders-table.test.cjs` covers the formatter: objects/null/omitted default, table shape, sorted columns, value/column alignment, empty-array, invalid format.
- Full suite: 364 tests, 0 fail (17 macOS-only skips). No XPI rebuild (per the release-commit convention).
