### PR TITLE
feat(messages): add getMessageHeaders and batchGetMessageHeaders

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -232,6 +232,38 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
       },
       {
+        name: "getMessageHeaders",
+        group: "messages", crud: "read",
+        title: "Get Message Headers",
+        description: "Read just the header fields (subject, from, to, cc, date, tags, flags, threading) of a single message by its ID. Lighter than getMessage — no body/MIME parse.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            messageId: { type: "string", description: "The message ID (from searchMessages results)" },
+            folderPath: { type: "string", description: "The folder URI path (from searchMessages results)" },
+          },
+          required: ["messageId", "folderPath"],
+        },
+      },
+      {
+        name: "batchGetMessageHeaders",
+        group: "messages", crud: "read",
+        title: "Batch Get Message Headers",
+        description: "Fetch headers for up to 200 messages that share one folder, in a single round-trip. Returns a map keyed by messageId; ids not found in the folder report a per-item error without failing the batch. Pair with searchMessages to enrich a result set without N round-trips.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            messageIds: {
+              type: "array",
+              description: "Message IDs to read headers for (hard cap 200, enforced by the handler). All must live in folderPath.",
+              items: { type: "string", description: "An RFC Message-ID (from searchMessages results)" },
+            },
+            folderPath: { type: "string", description: "The folder URI path shared by every id" },
+          },
+          required: ["messageIds", "folderPath"],
+        },
+      },
+      {
         name: "sendMail",
         group: "messages", crud: "create",
         title: "Compose Mail",
@@ -1526,6 +1558,39 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             /** Returns user-visible tag keywords from a message header, filtering out internal IMAP flags. */
             function getUserTags(msgHdr) {
               return (msgHdr.getStringProperty("keywords") || "").split(/\s+/).filter(k => k && !INTERNAL_KEYWORDS.has(k.toLowerCase()));
+            }
+
+            /**
+             * Single shared header-shape extractor used by both getMessageHeaders
+             * and batchGetMessageHeaders so the two tools return field-identical
+             * objects. Reads only nsIMsgDBHdr fields plus the two threading headers
+             * (References / In-Reply-To) via getStringProperty — no MIME parse.
+             *
+             * Field notes:
+             *   - id is the RFC Message-ID (msgHdr.messageId), exposed under `id`.
+             *   - subject/author/recipients prefer the RFC2047-decoded mime2Decoded*
+             *     variants, then raw, then "".
+             *   - date is microseconds-since-epoch / 1000 -> ms -> ISO-8601, or null.
+             *   - threadId is the DB/Gloda numeric thread id stringified, NOT a header.
+             *   - tags excludes internal IMAP/system keywords; always an array.
+             *   - size is msgHdr.messageSize only when it is a number, else null.
+             */
+            function msgHdrToHeaderObject(msgHdr) {
+              return {
+                id: msgHdr.messageId,
+                subject: msgHdr.mime2DecodedSubject || msgHdr.subject || "",
+                author: msgHdr.mime2DecodedAuthor || msgHdr.author || "",
+                recipients: msgHdr.mime2DecodedRecipients || msgHdr.recipients || "",
+                ccList: msgHdr.ccList || "",
+                date: msgHdr.date ? new Date(msgHdr.date / 1000).toISOString() : null,
+                tags: getUserTags(msgHdr),
+                isRead: msgHdr.isRead,
+                isFlagged: msgHdr.isFlagged,
+                threadId: msgHdr.threadId ? String(msgHdr.threadId) : null,
+                references: msgHdr.getStringProperty("references") || "",
+                inReplyTo: msgHdr.getStringProperty("in-reply-to") || "",
+                size: typeof msgHdr.messageSize === "number" ? msgHdr.messageSize : null,
+              };
             }
 
             /**
@@ -4176,6 +4241,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
             // END RAW MIME ATTACHMENT HELPERS
 
+            /**
+             * Reads only the header fields of a single message. Locates the
+             * nsIMsgDBHdr via findMessage (openFolder + direct/linear lookup)
+             * and returns the shared msgHdrToHeaderObject shape, or { error }.
+             * No body/MIME parse — synchronous, much lighter than getMessage.
+             */
+            function getMessageHeaders(messageId, folderPath) {
+              const found = findMessage(messageId, folderPath);
+              if (found.error) return { error: found.error };
+              return msgHdrToHeaderObject(found.msgHdr);
+            }
+
 	            function getMessage(messageId, folderPath, saveAttachments, bodyFormat, rawSource) {
 	              return new Promise((resolve) => {
 	                try {
@@ -4832,6 +4909,98 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 failed,
                 max: getMessagesLimit,
               };
+            }
+
+            /**
+             * Reads header fields for many messages that share one folder, in a
+             * single pass. Returns { headers, total, failed } where `headers` is a
+             * null-prototype map keyed by the input messageId; each value is either
+             * the shared msgHdrToHeaderObject shape (resolved) or
+             * { error: "not found in this folder" } (unresolved). `total` is the
+             * requested id count (messageIds.length, includes duplicates), `failed`
+             * is the number of unresolved ids.
+             *
+             * Algorithm is deliberately O(M), not O(M*N): one openFolder, a direct
+             * db.getMsgHdrForMessageID per id when available, then a SINGLE linear
+             * enumeration pass (capped at SCAN_CAP) only for the residual misses,
+             * early-exiting once every missing id is found. Unlike getMessageHeaders
+             * it does not call findMessage per id.
+             */
+            function batchGetMessageHeaders(messageIds, folderPath) {
+              if (!Array.isArray(messageIds)) {
+                return { error: "messageIds must be an array" };
+              }
+              // Empty input short-circuits without opening the folder.
+              if (messageIds.length === 0) {
+                return { headers: {}, total: 0, failed: 0 };
+              }
+              // Hard cap of 200 -- search-result pages are typically smaller; a
+              // caller wanting more should page. Enforced here in the handler
+              // (not via the schema) so over-cap returns a clear {error} value
+              // rather than a dispatch-layer rejection.
+              if (messageIds.length > 200) {
+                return { error: `Too many ids: ${messageIds.length}. Hard cap is 200; call multiple times if needed.` };
+              }
+
+              const opened = openFolder(folderPath);
+              if (opened.error) return opened;
+              const { db } = opened;
+
+              // wanted is the de-duplicated set of ids we still need to resolve.
+              const wanted = new Set(messageIds);
+              const found = new Map();
+
+              const hasDirect = typeof db.getMsgHdrForMessageID === "function";
+              if (hasDirect) {
+                for (const id of wanted) {
+                  try {
+                    const hdr = db.getMsgHdrForMessageID(id);
+                    if (hdr) found.set(id, hdr);
+                  } catch {
+                    // Swallow per-id lookup throws; the id stays in missSet for
+                    // the linear fallback below.
+                  }
+                }
+              }
+
+              // Single linear pass for ids the direct lookup missed.
+              const missSet = new Set();
+              for (const id of wanted) {
+                if (!found.has(id)) missSet.add(id);
+              }
+              if (missSet.size > 0) {
+                const SCAN_CAP = 50000;
+                let scanned = 0;
+                for (const hdr of db.enumerateMessages()) {
+                  if (scanned++ >= SCAN_CAP) break;
+                  const id = hdr.messageId;
+                  if (missSet.has(id)) {
+                    found.set(id, hdr);
+                    missSet.delete(id);
+                    if (missSet.size === 0) break;
+                  }
+                }
+              }
+
+              const headers = Object.create(null);
+              for (const id of messageIds) {
+                const hdr = found.get(id);
+                if (hdr) {
+                  headers[id] = msgHdrToHeaderObject(hdr);
+                } else {
+                  headers[id] = { error: "not found in this folder" };
+                }
+              }
+
+              // failed = number of map entries whose value is the {error} form.
+              // Counted over the de-duplicated keys (duplicate ids collapse to one
+              // entry), while total reflects the raw requested count.
+              let failed = 0;
+              for (const key of Object.keys(headers)) {
+                if (headers[key] && headers[key].error) failed++;
+              }
+
+              return { headers, total: messageIds.length, failed };
             }
 
             /**
@@ -6515,6 +6684,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return await getMessage(args.messageId, args.folderPath, args.saveAttachments, args.bodyFormat, args.rawSource);
                 case "getMessages":
                   return await getMessages(args.messages, args.saveAttachments, args.bodyFormat, args.rawSource);
+                case "getMessageHeaders":
+                  return getMessageHeaders(args.messageId, args.folderPath);
+                case "batchGetMessageHeaders":
+                  return batchGetMessageHeaders(args.messageIds, args.folderPath);
                 case "searchContacts":
                   return searchContacts(args.query || "", args.maxResults);
                 case "createContact":

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -77,6 +77,8 @@ const ALL_TOOLS = [
   { name: "searchMessages", group: "messages", crud: "read" },
   { name: "getMessage", group: "messages", crud: "read" },
   { name: "getMessages", group: "messages", crud: "read" },
+  { name: "getMessageHeaders", group: "messages", crud: "read" },
+  { name: "batchGetMessageHeaders", group: "messages", crud: "read" },
   { name: "getRecentMessages", group: "messages", crud: "read" },
   { name: "displayMessage", group: "messages", crud: "read" },
   { name: "sendMail", group: "messages", crud: "create" },

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -217,6 +217,31 @@ const sampleTools = [
     },
   },
   {
+    name: "getMessageHeaders",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageId: { type: "string" },
+        folderPath: { type: "string" },
+      },
+      required: ["messageId", "folderPath"],
+    },
+  },
+  {
+    name: "batchGetMessageHeaders",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        folderPath: { type: "string" },
+      },
+      required: ["messageIds", "folderPath"],
+    },
+  },
+  {
     name: "getAccountAccess",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
@@ -528,5 +553,109 @@ describe('Validation: getMessages batch size', () => {
     });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /at most 10/);
+  });
+});
+
+describe('Validation: getMessageHeaders', () => {
+  it('accepts messageId + folderPath', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects missing messageId', () => {
+    const errors = validate('getMessageHeaders', {
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: messageId/);
+  });
+
+  it('rejects missing folderPath', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: folderPath/);
+  });
+
+  it('rejects messageId of the wrong type', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: 42,
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be string/);
+  });
+
+  it('rejects unknown parameters', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+      headers: ['Subject'],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Unknown parameter: headers/);
+  });
+});
+
+describe('Validation: batchGetMessageHeaders', () => {
+  it('accepts a valid batch', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: Array.from({ length: 10 }, (_, index) => `<message-${index}@example.com>`),
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  // No schema minItems: an empty array is valid at the dispatch layer; the
+  // handler short-circuits it to { headers: {}, total: 0, failed: 0 }.
+  it('accepts an empty messageIds array (handler returns the empty fast path)', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: [],
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  // No schema maxItems: the 200-id hard cap lives in the handler (returning a
+  // clear { error } value), not in validation, so large arrays pass validation.
+  it('does not bound messageIds at the schema level', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: Array.from({ length: 250 }, (_, index) => `<message-${index}@example.com>`),
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects messageIds passed as a non-array', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an array/);
+  });
+
+  it('rejects missing folderPath', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: ['<abc@example.com>'],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: folderPath/);
+  });
+
+  // Validation is SHALLOW: it enforces the messageIds array type but does NOT
+  // recurse into items, so a null element passes top-level validation (per-id
+  // handling happens inside the handler, which records a per-item "not found in
+  // this folder" error rather than aborting the batch).
+  it('does not reject a null array item at the top level (shallow validation)', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: ['<abc@example.com>', null],
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
   });
 });


### PR DESCRIPTION
## What

Two read-only, header-only message tools for agent workflows that need to triage or enrich a result set without decoding bodies or paying N round-trips.

- **`getMessageHeaders(messageId, folderPath)`** — returns a flat header object: `id, subject, author, recipients, ccList, date, tags, isRead, isFlagged, threadId, references, inReplyTo, size`. Goes through the same `findMessage → openFolder → getAccessibleFolder` access gate as `getMessage`.
- **`batchGetMessageHeaders(messageIds, folderPath)`** — one folder open + a single linear enumeration fallback (O(M), not O(M·N)) for ids the direct `getMsgHdrForMessageID` lookup misses. Returns `{ headers: { id → header | { error } }, total, failed }`.

Both reuse a shared `msgHdrToHeaderObject` extractor so their field shape matches what the other read tools emit.

## Why

Agents frequently want just the headers (sender / subject / date / threading) for a page of search results — to dedupe, thread, or decide which messages to fully fetch. Today that means N `getMessage` calls, each decoding the body. These tools make header triage a single call.

## Tests

`test/validation.test.cjs` covers both schemas (valid, missing-required, wrong-type, batch shape/shallow-null); `ALL_TOOLS` updated. Full suite: **386 pass, 0 fail**. `eslint .`: **0 errors**.

## Notes

- The 200-id hard cap on `batchGetMessageHeaders` lives in the handler (returns a clear `{ error }`) rather than the schema, so the empty-input fast path (`{ headers: {}, total: 0, failed: 0 }`) stays reachable and over-cap is a normal tool result, not a dispatch rejection.
- `getMessageHeaders` reuses the existing `findMessage`, so its not-found behavior matches `getMessage`.
