### PR TITLE
fix(compat): bump strict_max_version to 152.* for Thunderbird 152

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,7 @@
     "gecko": {
       "id": "thunderbird-mcp@tkasperczyk.dev",
       "strict_min_version": "102.0",
-      "strict_max_version": "151.*"
+      "strict_max_version": "152.*"
     }
   },
   "icons": {


### PR DESCRIPTION
## Summary

Thunderbird 152 was released and the extension caps compatibility at `strict_max_version: "151.*"`. As a result, TB 152 reports "Thunderbird MCP is incompatible with Thunderbird 152.0" and refuses to load the add-on.

This bumps the cap to `152.*` so users on the new version can install and run the extension. It is the same trivial-but-blocking fix as the earlier 150 -> 151 bump (#114, #116, commit 92cfff3).

Closes #146.

## Change

- `extension/manifest.json`: `strict_max_version` `151.*` -> `152.*`

## Test plan

- Built the XPI from this branch and installed it on Thunderbird 152.0; the add-on now loads instead of being rejected as incompatible.
- Full test suite passes (`npm test`): 375 passing, 0 failing.
