### PR TITLE
feat(messages): add searchByThread and getSenderHistory (stacked on #145)

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -232,6 +232,38 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
       },
       {
+        name: "getMessageHeaders",
+        group: "messages", crud: "read",
+        title: "Get Message Headers",
+        description: "Read just the header fields (subject, from, to, cc, date, tags, flags, threading) of a single message by its ID. Lighter than getMessage — no body/MIME parse.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            messageId: { type: "string", description: "The message ID (from searchMessages results)" },
+            folderPath: { type: "string", description: "The folder URI path (from searchMessages results)" },
+          },
+          required: ["messageId", "folderPath"],
+        },
+      },
+      {
+        name: "batchGetMessageHeaders",
+        group: "messages", crud: "read",
+        title: "Batch Get Message Headers",
+        description: "Fetch headers for up to 200 messages that share one folder, in a single round-trip. Returns a map keyed by messageId; ids not found in the folder report a per-item error without failing the batch. Pair with searchMessages to enrich a result set without N round-trips.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            messageIds: {
+              type: "array",
+              description: "Message IDs to read headers for (hard cap 200, enforced by the handler). All must live in folderPath.",
+              items: { type: "string", description: "An RFC Message-ID (from searchMessages results)" },
+            },
+            folderPath: { type: "string", description: "The folder URI path shared by every id" },
+          },
+          required: ["messageIds", "folderPath"],
+        },
+      },
+      {
         name: "sendMail",
         group: "messages", crud: "create",
         title: "Compose Mail",
@@ -1526,6 +1558,39 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             /** Returns user-visible tag keywords from a message header, filtering out internal IMAP flags. */
             function getUserTags(msgHdr) {
               return (msgHdr.getStringProperty("keywords") || "").split(/\s+/).filter(k => k && !INTERNAL_KEYWORDS.has(k.toLowerCase()));
+            }
+
+            /**
+             * Single shared header-shape extractor used by both getMessageHeaders
+             * and batchGetMessageHeaders so the two tools return field-identical
+             * objects. Reads only nsIMsgDBHdr fields plus the two threading headers
+             * (References / In-Reply-To) via getStringProperty — no MIME parse.
+             *
+             * Field notes:
+             *   - id is the RFC Message-ID (msgHdr.messageId), exposed under `id`.
+             *   - subject/author/recipients prefer the RFC2047-decoded mime2Decoded*
+             *     variants, then raw, then "".
+             *   - date is microseconds-since-epoch / 1000 -> ms -> ISO-8601, or null.
+             *   - threadId is the DB/Gloda numeric thread id stringified, NOT a header.
+             *   - tags excludes internal IMAP/system keywords; always an array.
+             *   - size is msgHdr.messageSize only when it is a number, else null.
+             */
+            function msgHdrToHeaderObject(msgHdr) {
+              return {
+                id: msgHdr.messageId,
+                subject: msgHdr.mime2DecodedSubject || msgHdr.subject || "",
+                author: msgHdr.mime2DecodedAuthor || msgHdr.author || "",
+                recipients: msgHdr.mime2DecodedRecipients || msgHdr.recipients || "",
+                ccList: msgHdr.ccList || "",
+                date: msgHdr.date ? new Date(msgHdr.date / 1000).toISOString() : null,
+                tags: getUserTags(msgHdr),
+                isRead: msgHdr.isRead,
+                isFlagged: msgHdr.isFlagged,
+                threadId: msgHdr.threadId ? String(msgHdr.threadId) : null,
+                references: msgHdr.getStringProperty("references") || "",
+                inReplyTo: msgHdr.getStringProperty("in-reply-to") || "",
+                size: typeof msgHdr.messageSize === "number" ? msgHdr.messageSize : null,
+              };
             }
 
             /**
@@ -4176,6 +4241,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
             // END RAW MIME ATTACHMENT HELPERS
 
+            /**
+             * Reads only the header fields of a single message. Locates the
+             * nsIMsgDBHdr via findMessage (openFolder + direct/linear lookup)
+             * and returns the shared msgHdrToHeaderObject shape, or { error }.
+             * No body/MIME parse — synchronous, much lighter than getMessage.
+             */
+            function getMessageHeaders(messageId, folderPath) {
+              const found = findMessage(messageId, folderPath);
+              if (found.error) return { error: found.error };
+              return msgHdrToHeaderObject(found.msgHdr);
+            }
+
 	            function getMessage(messageId, folderPath, saveAttachments, bodyFormat, rawSource) {
 	              return new Promise((resolve) => {
 	                try {
@@ -4832,6 +4909,98 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 failed,
                 max: getMessagesLimit,
               };
+            }
+
+            /**
+             * Reads header fields for many messages that share one folder, in a
+             * single pass. Returns { headers, total, failed } where `headers` is a
+             * null-prototype map keyed by the input messageId; each value is either
+             * the shared msgHdrToHeaderObject shape (resolved) or
+             * { error: "not found in this folder" } (unresolved). `total` is the
+             * requested id count (messageIds.length, includes duplicates), `failed`
+             * is the number of unresolved ids.
+             *
+             * Algorithm is deliberately O(M), not O(M*N): one openFolder, a direct
+             * db.getMsgHdrForMessageID per id when available, then a SINGLE linear
+             * enumeration pass (capped at SCAN_CAP) only for the residual misses,
+             * early-exiting once every missing id is found. Unlike getMessageHeaders
+             * it does not call findMessage per id.
+             */
+            function batchGetMessageHeaders(messageIds, folderPath) {
+              if (!Array.isArray(messageIds)) {
+                return { error: "messageIds must be an array" };
+              }
+              // Empty input short-circuits without opening the folder.
+              if (messageIds.length === 0) {
+                return { headers: {}, total: 0, failed: 0 };
+              }
+              // Hard cap of 200 -- search-result pages are typically smaller; a
+              // caller wanting more should page. Enforced here in the handler
+              // (not via the schema) so over-cap returns a clear {error} value
+              // rather than a dispatch-layer rejection.
+              if (messageIds.length > 200) {
+                return { error: `Too many ids: ${messageIds.length}. Hard cap is 200; call multiple times if needed.` };
+              }
+
+              const opened = openFolder(folderPath);
+              if (opened.error) return opened;
+              const { db } = opened;
+
+              // wanted is the de-duplicated set of ids we still need to resolve.
+              const wanted = new Set(messageIds);
+              const found = new Map();
+
+              const hasDirect = typeof db.getMsgHdrForMessageID === "function";
+              if (hasDirect) {
+                for (const id of wanted) {
+                  try {
+                    const hdr = db.getMsgHdrForMessageID(id);
+                    if (hdr) found.set(id, hdr);
+                  } catch {
+                    // Swallow per-id lookup throws; the id stays in missSet for
+                    // the linear fallback below.
+                  }
+                }
+              }
+
+              // Single linear pass for ids the direct lookup missed.
+              const missSet = new Set();
+              for (const id of wanted) {
+                if (!found.has(id)) missSet.add(id);
+              }
+              if (missSet.size > 0) {
+                const SCAN_CAP = 50000;
+                let scanned = 0;
+                for (const hdr of db.enumerateMessages()) {
+                  if (scanned++ >= SCAN_CAP) break;
+                  const id = hdr.messageId;
+                  if (missSet.has(id)) {
+                    found.set(id, hdr);
+                    missSet.delete(id);
+                    if (missSet.size === 0) break;
+                  }
+                }
+              }
+
+              const headers = Object.create(null);
+              for (const id of messageIds) {
+                const hdr = found.get(id);
+                if (hdr) {
+                  headers[id] = msgHdrToHeaderObject(hdr);
+                } else {
+                  headers[id] = { error: "not found in this folder" };
+                }
+              }
+
+              // failed = number of map entries whose value is the {error} form.
+              // Counted over the de-duplicated keys (duplicate ids collapse to one
+              // entry), while total reflects the raw requested count.
+              let failed = 0;
+              for (const key of Object.keys(headers)) {
+                if (headers[key] && headers[key].error) failed++;
+              }
+
+              return { headers, total: messageIds.length, failed };
             }
 
             /**
@@ -6515,6 +6684,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return await getMessage(args.messageId, args.folderPath, args.saveAttachments, args.bodyFormat, args.rawSource);
                 case "getMessages":
                   return await getMessages(args.messages, args.saveAttachments, args.bodyFormat, args.rawSource);
+                case "getMessageHeaders":
+                  return getMessageHeaders(args.messageId, args.folderPath);
+                case "batchGetMessageHeaders":
+                  return batchGetMessageHeaders(args.messageIds, args.folderPath);
                 case "searchContacts":
                   return searchContacts(args.query || "", args.maxResults);
                 case "createContact":

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -264,6 +264,37 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
       },
       {
+        name: "getSenderHistory",
+        group: "messages", crud: "read",
+        title: "Get Sender History",
+        description: "Return recent message headers from a given email address, scanned across the inbox of every accessible account. Useful for 'have I corresponded with this person before?' or 'have we already approached this outreach target?' decisions before drafting a reply.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            email: { type: "string", description: "Sender email address to match (case-insensitive substring match against the author field)" },
+            maxResults: { type: "integer", description: "Cap on returned headers (default 50, max 200)" },
+            scanCap: { type: "integer", description: "Hard cap on messages enumerated per folder before stopping (default 5000, max 50000)" },
+            sinceDays: { type: "integer", description: "Restrict to messages from the last N days (default unlimited)" },
+          },
+          required: ["email"],
+        },
+      },
+      {
+        name: "searchByThread",
+        group: "messages", crud: "read",
+        title: "Search By Thread",
+        description: "Given any messageId + folderPath, return headers for every other message in the same thread. Uses msgHdr.threadId. Results are headers-only -- call getMessage on a specific id for its body.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            messageId: { type: "string", description: "Any message in the thread you want to fetch" },
+            folderPath: { type: "string", description: "Folder URI containing the message" },
+            maxResults: { type: "integer", description: "Cap on returned headers (default 100, max 500)" },
+          },
+          required: ["messageId", "folderPath"],
+        },
+      },
+      {
         name: "sendMail",
         group: "messages", crud: "create",
         title: "Compose Mail",
@@ -5004,6 +5035,106 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
 
             /**
+             * Return recent message headers from a given email address, scanned
+             * across the inbox (or root fallback) of every accessible account.
+             * Case-insensitive substring match against the decoded author field.
+             * Synchronous. Newest-first.
+             */
+            function getSenderHistory(email, maxResults, scanCap, sinceDays) {
+              if (typeof email !== "string" || !email.trim()) {
+                return { error: "email must be a non-empty string" };
+              }
+              const wantLower = email.toLowerCase();
+              const cap = Number.isFinite(maxResults) && maxResults > 0
+                ? Math.min(Math.floor(maxResults), 200)
+                : 50;
+              const scanLimit = Number.isFinite(scanCap) && scanCap > 0
+                ? Math.min(Math.floor(scanCap), 50000)
+                : 5000;
+              const sinceMicros = Number.isFinite(sinceDays) && sinceDays > 0
+                ? (Date.now() - sinceDays * 86400 * 1000) * 1000
+                : null;
+
+              const FLAG_INBOX = 0x1000;
+              const results = [];
+              let totalScanned = 0;
+              for (const account of getAccessibleAccounts()) {
+                if (results.length >= cap) break;
+                let inbox = null;
+                try {
+                  const root = account.incomingServer && account.incomingServer.rootFolder;
+                  if (!root) continue;
+                  if (typeof root.getFolderWithFlags === "function") {
+                    try { inbox = root.getFolderWithFlags(FLAG_INBOX); } catch { /* ignore */ }
+                  }
+                  if (!inbox) inbox = root;
+                  const db = inbox.msgDatabase;
+                  if (!db) continue;
+                  let scanned = 0;
+                  for (const hdr of db.enumerateMessages()) {
+                    scanned++;
+                    totalScanned++;
+                    if (scanned > scanLimit) break;
+                    if (sinceMicros !== null && hdr.date && hdr.date < sinceMicros) continue;
+                    const author = (hdr.mime2DecodedAuthor || hdr.author || "").toLowerCase();
+                    if (!author.includes(wantLower)) continue;
+                    const obj = msgHdrToHeaderObject(hdr);
+                    obj.folderPath = inbox.URI;
+                    obj._ts = hdr.date ? hdr.date / 1000 : 0;
+                    results.push(obj);
+                    if (results.length >= cap * 2) break; // generous pre-sort buffer
+                  }
+                } catch { /* skip inaccessible account */ }
+              }
+
+              results.sort((a, b) => (b._ts || 0) - (a._ts || 0));
+              const trimmed = results.slice(0, cap).map(({ _ts, ...rest }) => rest);
+              return {
+                sender: email,
+                messages: trimmed,
+                totalScanned,
+                truncated: results.length > cap,
+              };
+            }
+
+            /**
+             * Walk a folder once and return all headers that share the
+             * threadId of the anchor message. The anchor itself is included.
+             * Newest-first.
+             */
+            function searchByThread(messageId, folderPath, maxResults) {
+              const found = findMessage(messageId, folderPath);
+              if (found.error) return { error: found.error };
+              const { msgHdr: anchor, db } = found;
+              const threadId = anchor.threadId;
+              if (!threadId) {
+                return { thread: [msgHdrToHeaderObject(anchor)], threadId: null, anchored: true };
+              }
+              const cap = Number.isFinite(maxResults) && maxResults > 0
+                ? Math.min(Math.floor(maxResults), 500)
+                : 100;
+              const results = [];
+              const SCAN_CAP = 50000;
+              let scanned = 0;
+              for (const hdr of db.enumerateMessages()) {
+                scanned++;
+                if (scanned > SCAN_CAP) break;
+                if (hdr.threadId === threadId) {
+                  results.push({ _hdr: hdr, _ts: hdr.date ? hdr.date / 1000 : 0 });
+                  if (results.length >= cap) break;
+                }
+              }
+              results.sort((a, b) => b._ts - a._ts);
+              return {
+                threadId: String(threadId),
+                anchorId: anchor.messageId,
+                thread: results.map(r => msgHdrToHeaderObject(r._hdr)),
+                truncated: results.length >= cap,
+                scanned,
+              };
+            }
+
+            /**
              * Composes a new email. Opens a compose window for review, or sends
              * directly when skipReview is true.
              *
@@ -6688,6 +6819,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return getMessageHeaders(args.messageId, args.folderPath);
                 case "batchGetMessageHeaders":
                   return batchGetMessageHeaders(args.messageIds, args.folderPath);
+                case "getSenderHistory":
+                  return getSenderHistory(args.email, args.maxResults, args.scanCap, args.sinceDays);
+                case "searchByThread":
+                  return searchByThread(args.messageId, args.folderPath, args.maxResults);
                 case "searchContacts":
                   return searchContacts(args.query || "", args.maxResults);
                 case "createContact":

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -79,6 +79,8 @@ const ALL_TOOLS = [
   { name: "getMessages", group: "messages", crud: "read" },
   { name: "getMessageHeaders", group: "messages", crud: "read" },
   { name: "batchGetMessageHeaders", group: "messages", crud: "read" },
+  { name: "getSenderHistory", group: "messages", crud: "read" },
+  { name: "searchByThread", group: "messages", crud: "read" },
   { name: "getRecentMessages", group: "messages", crud: "read" },
   { name: "displayMessage", group: "messages", crud: "read" },
   { name: "sendMail", group: "messages", crud: "create" },

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -77,6 +77,8 @@ const ALL_TOOLS = [
   { name: "searchMessages", group: "messages", crud: "read" },
   { name: "getMessage", group: "messages", crud: "read" },
   { name: "getMessages", group: "messages", crud: "read" },
+  { name: "getMessageHeaders", group: "messages", crud: "read" },
+  { name: "batchGetMessageHeaders", group: "messages", crud: "read" },
   { name: "getRecentMessages", group: "messages", crud: "read" },
   { name: "displayMessage", group: "messages", crud: "read" },
   { name: "sendMail", group: "messages", crud: "create" },

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -63,6 +63,12 @@ function createValidator(tools) {
         if (typeof value !== "object" || Array.isArray(value)) {
           errors.push(`Parameter '${key}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
         }
+      } else if (expectedType === "integer") {
+        // JSON Schema "integer" is a whole number. typeof reports
+        // "number" for both integers and floats, so check explicitly.
+        if (typeof value !== "number" || !Number.isInteger(value)) {
+          errors.push(`Parameter '${key}' must be an integer, got ${typeof value === "number" ? "non-integer number" : typeof value}`);
+        }
       } else if (expectedType && typeof value !== expectedType) {
         errors.push(`Parameter '${key}' must be ${expectedType}, got ${typeof value}`);
       }
@@ -244,6 +250,31 @@ const sampleTools = [
   {
     name: "getAccountAccess",
     inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "getSenderHistory",
+    inputSchema: {
+      type: "object",
+      properties: {
+        email: { type: "string" },
+        maxResults: { type: "integer" },
+        scanCap: { type: "integer" },
+        sinceDays: { type: "integer" },
+      },
+      required: ["email"],
+    },
+  },
+  {
+    name: "searchByThread",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageId: { type: "string" },
+        folderPath: { type: "string" },
+        maxResults: { type: "integer" },
+      },
+      required: ["messageId", "folderPath"],
+    },
   },
 ];
 
@@ -655,6 +686,126 @@ describe('Validation: batchGetMessageHeaders', () => {
     const errors = validate('batchGetMessageHeaders', {
       messageIds: ['<abc@example.com>', null],
       folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+});
+
+describe('Validation: getSenderHistory', () => {
+  it('accepts a valid email-only call', () => {
+    const errors = validate('getSenderHistory', {
+      email: 'alice@example.com',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('accepts the full set of integer caps', () => {
+    const errors = validate('getSenderHistory', {
+      email: 'alice@example.com',
+      maxResults: 50,
+      scanCap: 5000,
+      sinceDays: 30,
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects missing email', () => {
+    const errors = validate('getSenderHistory', {
+      maxResults: 50,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: email/);
+  });
+
+  it('rejects email passed as a non-string', () => {
+    const errors = validate('getSenderHistory', {
+      email: 123,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be string/);
+  });
+
+  // The "default 50, max 200" / "default 5000, max 50000" caps live in the
+  // handler (silent Math.min clamp + default), NOT the schema, so out-of-range
+  // integers pass validation and are clamped at runtime.
+  it('does not bound maxResults/scanCap at the schema level', () => {
+    const errors = validate('getSenderHistory', {
+      email: 'alice@example.com',
+      maxResults: 9999,
+      scanCap: 9999999,
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects a non-integer (float) maxResults', () => {
+    const errors = validate('getSenderHistory', {
+      email: 'alice@example.com',
+      maxResults: 12.5,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an integer/);
+  });
+
+  it('rejects unknown parameters', () => {
+    const errors = validate('getSenderHistory', {
+      email: 'alice@example.com',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Unknown parameter: folderPath/);
+  });
+});
+
+describe('Validation: searchByThread', () => {
+  it('accepts a valid messageId + folderPath call', () => {
+    const errors = validate('searchByThread', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('accepts an explicit maxResults', () => {
+    const errors = validate('searchByThread', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+      maxResults: 100,
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects missing messageId', () => {
+    const errors = validate('searchByThread', {
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: messageId/);
+  });
+
+  it('rejects missing folderPath', () => {
+    const errors = validate('searchByThread', {
+      messageId: '<abc@example.com>',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: folderPath/);
+  });
+
+  it('rejects folderPath passed as a non-string', () => {
+    const errors = validate('searchByThread', {
+      messageId: '<abc@example.com>',
+      folderPath: 12345,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be string/);
+  });
+
+  // The "default 100, max 500" cap lives in the handler (silent clamp), not the
+  // schema, so an over-cap integer passes validation.
+  it('does not bound maxResults at the schema level', () => {
+    const errors = validate('searchByThread', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+      maxResults: 99999,
     });
     assert.deepStrictEqual(errors, []);
   });

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -217,6 +217,31 @@ const sampleTools = [
     },
   },
   {
+    name: "getMessageHeaders",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageId: { type: "string" },
+        folderPath: { type: "string" },
+      },
+      required: ["messageId", "folderPath"],
+    },
+  },
+  {
+    name: "batchGetMessageHeaders",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        folderPath: { type: "string" },
+      },
+      required: ["messageIds", "folderPath"],
+    },
+  },
+  {
     name: "getAccountAccess",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
@@ -528,5 +553,109 @@ describe('Validation: getMessages batch size', () => {
     });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /at most 10/);
+  });
+});
+
+describe('Validation: getMessageHeaders', () => {
+  it('accepts messageId + folderPath', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects missing messageId', () => {
+    const errors = validate('getMessageHeaders', {
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: messageId/);
+  });
+
+  it('rejects missing folderPath', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: folderPath/);
+  });
+
+  it('rejects messageId of the wrong type', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: 42,
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be string/);
+  });
+
+  it('rejects unknown parameters', () => {
+    const errors = validate('getMessageHeaders', {
+      messageId: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+      headers: ['Subject'],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Unknown parameter: headers/);
+  });
+});
+
+describe('Validation: batchGetMessageHeaders', () => {
+  it('accepts a valid batch', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: Array.from({ length: 10 }, (_, index) => `<message-${index}@example.com>`),
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  // No schema minItems: an empty array is valid at the dispatch layer; the
+  // handler short-circuits it to { headers: {}, total: 0, failed: 0 }.
+  it('accepts an empty messageIds array (handler returns the empty fast path)', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: [],
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  // No schema maxItems: the 200-id hard cap lives in the handler (returning a
+  // clear { error } value), not in validation, so large arrays pass validation.
+  it('does not bound messageIds at the schema level', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: Array.from({ length: 250 }, (_, index) => `<message-${index}@example.com>`),
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('rejects messageIds passed as a non-array', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: '<abc@example.com>',
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an array/);
+  });
+
+  it('rejects missing folderPath', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: ['<abc@example.com>'],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: folderPath/);
+  });
+
+  // Validation is SHALLOW: it enforces the messageIds array type but does NOT
+  // recurse into items, so a null element passes top-level validation (per-id
+  // handling happens inside the handler, which records a per-item "not found in
+  // this folder" error rather than aborting the batch).
+  it('does not reject a null array item at the top level (shallow validation)', () => {
+    const errors = validate('batchGetMessageHeaders', {
+      messageIds: ['<abc@example.com>', null],
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.deepStrictEqual(errors, []);
   });
 });


### PR DESCRIPTION
> **Stacked on #145** — please review/merge that first. The `getMessageHeaders` / `batchGetMessageHeaders` commit shown here will drop out of this diff once #145 lands.

## What

Two more read-only, header-only query tools, built on the shared `msgHdrToHeaderObject` extractor introduced in #145.

- **`searchByThread(messageId, folderPath, maxResults)`** — walks the anchor's folder once and returns headers for every message sharing its `threadId` (the anchor is included), newest-first. Returns `{ threadId, anchorId, thread, truncated, scanned }`, or `{ thread: [anchor], threadId: null, anchored: true }` when the anchor has no thread id. Result cap default 100 / max 500; enumeration bounded by a local `SCAN_CAP` of 50000.
- **`getSenderHistory(email, maxResults, scanCap, sinceDays)`** — scans the inbox of each accessible account for messages from a sender (case-insensitive substring on the author field), newest-first. `maxResults` default 50 / max 200; per-account `scanCap` default 5000 / max 50000; optional `sinceDays` window.

Both reuse the existing folder/account access gate, and the caps are enforced imperatively in the handlers (consistent with the rest of the batch surface) rather than via schema bounds.

## Why

These round out header-level triage for agents: "show me the whole thread" and "what has this person sent me recently" without N body fetches.

## Tests

`test/validation.test.cjs` covers both schemas; `ALL_TOOLS` updated (structural test passes). Full suite green, `eslint .` 0 errors.

## Known limitation

`getSenderHistory` stops scanning once `maxResults` matches are collected, so "newest-first across every account" holds within the accounts actually visited rather than globally. Documented in the schema description; happy to make it strictly global if you'd prefer.

## Follow-up

`searchAttachments` (the third tool in this family) is intentionally held back for its own PR — its MIME-parse step needs a bounded-concurrency pass before it's a good upstream citizen.
