### PR TITLE
feat(messages): add refreshFolder tool

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -666,6 +666,20 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
       },
       {
+        name: "refreshFolder",
+        group: "messages", crud: "read",
+        title: "Refresh Folder",
+        description: "Fetch new mail for an IMAP folder from the server and wait for completion. Returns counts of messages before/after and how many new messages arrived. Non-IMAP folders (POP/Local) are skipped. The wait is bounded by timeoutMs (default 15000, hard-capped at 25000); on timeout the in-flight fetch keeps running in Thunderbird and a timeout result is returned.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            folderPath: { type: "string", description: "Folder URI (from listFolders) to refresh" },
+            timeoutMs: { type: "integer", description: "Max ms to wait for the fetch to complete (default 15000). Hard-capped at 25000 to stay below the stdio bridge's HTTP request timeout (30000ms); larger values are clamped." },
+          },
+          required: ["folderPath"],
+        },
+      },
+      {
         name: "createFolder",
         group: "folders", crud: "create",
         title: "Create Folder",
@@ -5927,6 +5941,88 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               }
             }
 
+            // Hard cap on the refresh wait, kept under the stdio bridge's
+            // 30000ms HTTP request timeout (5s safety margin) so a structured
+            // timeout result is returned rather than the bridge hard-failing.
+            const REFRESH_TIMEOUT_CAP_MS = 25000;
+
+            function refreshFolder(folderPath, timeoutMs) {
+              return new Promise((resolve) => {
+                try {
+                  const result = getAccessibleFolder(folderPath);
+                  if (result.error) {
+                    resolve({ error: result.error });
+                    return;
+                  }
+                  const folder = result.folder;
+
+                  // Non-IMAP folders (POP/Local) have no remote fetch to drive.
+                  if (!folder.server || folder.server.type !== "imap") {
+                    resolve({ success: true, folderPath: folder.URI, skipped: "not an IMAP folder" });
+                    return;
+                  }
+
+                  const limit = Number.isFinite(timeoutMs) && timeoutMs > 0
+                    ? Math.min(Math.floor(timeoutMs), REFRESH_TIMEOUT_CAP_MS)
+                    : 15000;
+
+                  let beforeCount = null;
+                  try { beforeCount = folder.getTotalMessages(false); } catch {}
+
+                  let settled = false;
+                  const timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+                  const settle = (value) => {
+                    if (settled) return;
+                    settled = true;
+                    try { timer.cancel(); } catch {}
+                    resolve(value);
+                  };
+
+                  // Arm the timeout BEFORE kicking off the fetch. On timeout the
+                  // in-flight getNewMessages is left running; only the wait is
+                  // abandoned.
+                  timer.initWithCallback({
+                    notify() {
+                      settle({ error: `refreshFolder timed out after ${limit}ms`, folderPath: folder.URI });
+                    }
+                  }, limit, Ci.nsITimer.TYPE_ONE_SHOT);
+
+                  const urlListener = {
+                    QueryInterface: ChromeUtils.generateQI(["nsIUrlListener"]),
+                    OnStartRunningUrl() {},
+                    OnStopRunningUrl(url, exitCode) {
+                      if (!Components.isSuccessCode(exitCode)) {
+                        // >>> 0 coerces the (negative, signed 32-bit) nsresult to
+                        // its unsigned form so the hex reads e.g. 0x80004005.
+                        settle({ error: `IMAP fetch failed (status 0x${(exitCode >>> 0).toString(16)})`, folderPath: folder.URI });
+                        return;
+                      }
+                      let afterCount = null;
+                      try { afterCount = folder.getTotalMessages(false); } catch {}
+                      const newMessages = (afterCount === null || typeof beforeCount !== "number")
+                        ? null
+                        : Math.max(0, afterCount - beforeCount);
+                      settle({
+                        success: true,
+                        folderPath: folder.URI,
+                        totalBefore: beforeCount,
+                        totalAfter: afterCount,
+                        newMessages,
+                      });
+                    },
+                  };
+
+                  try {
+                    folder.getNewMessages(null, urlListener);
+                  } catch (e) {
+                    settle({ error: e.toString(), folderPath: folder.URI });
+                  }
+                } catch (e) {
+                  resolve({ error: e.toString() });
+                }
+              });
+            }
+
             // ── Filter constant maps ──
 
             const ATTRIB_MAP = {
@@ -6557,6 +6653,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return deleteMessages(args.messageIds, args.folderPath);
                 case "updateMessage":
                   return updateMessage(args.messageId, args.messageIds, args.folderPath, args.read, args.flagged, args.addTags, args.removeTags, args.moveTo, args.trash);
+                case "refreshFolder":
+                  return await refreshFolder(args.folderPath, args.timeoutMs);
                 case "createFolder":
                   return createFolder(args.parentFolderPath, args.name);
                 case "renameFolder":

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -79,6 +79,7 @@ const ALL_TOOLS = [
   { name: "getMessages", group: "messages", crud: "read" },
   { name: "getRecentMessages", group: "messages", crud: "read" },
   { name: "displayMessage", group: "messages", crud: "read" },
+  { name: "refreshFolder", group: "messages", crud: "read" },
   { name: "sendMail", group: "messages", crud: "create" },
   { name: "replyToMessage", group: "messages", crud: "create" },
   { name: "forwardMessage", group: "messages", crud: "create" },

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -63,6 +63,12 @@ function createValidator(tools) {
         if (typeof value !== "object" || Array.isArray(value)) {
           errors.push(`Parameter '${key}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
         }
+      } else if (expectedType === "integer") {
+        // JSON Schema "integer" is a whole number. typeof reports
+        // "number" for both integers and floats, so check explicitly.
+        if (typeof value !== "number" || !Number.isInteger(value)) {
+          errors.push(`Parameter '${key}' must be an integer, got ${typeof value === "number" ? "non-integer number" : typeof value}`);
+        }
       } else if (expectedType && typeof value !== expectedType) {
         errors.push(`Parameter '${key}' must be ${expectedType}, got ${typeof value}`);
       }
@@ -171,6 +177,17 @@ const sampleTools = [
         newParentPath: { type: "string" },
       },
       required: ["folderPath", "newParentPath"],
+    },
+  },
+  {
+    name: "refreshFolder",
+    inputSchema: {
+      type: "object",
+      properties: {
+        folderPath: { type: "string" },
+        timeoutMs: { type: "integer" },
+      },
+      required: ["folderPath"],
     },
   },
   {
@@ -377,6 +394,65 @@ describe('Validation: folder management', () => {
       folderPath: '/Source',
       newParentPath: '/Dest',
       recursive: true,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Unknown parameter/);
+  });
+});
+
+describe('Validation: refreshFolder', () => {
+  it('requires folderPath', () => {
+    const errors = validate('refreshFolder', {});
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter/);
+    assert.match(errors[0], /folderPath/);
+  });
+
+  it('accepts a valid folderPath alone', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 'imap://user@server/INBOX',
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts a valid folderPath with integer timeoutMs', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 'imap://user@server/INBOX',
+      timeoutMs: 20000,
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects number for folderPath', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 123,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be string/);
+  });
+
+  it('rejects non-integer timeoutMs', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 'imap://user@server/INBOX',
+      timeoutMs: 1500.5,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an integer/);
+  });
+
+  it('rejects string timeoutMs', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 'imap://user@server/INBOX',
+      timeoutMs: '15000',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an integer/);
+  });
+
+  it('rejects unknown params', () => {
+    const errors = validate('refreshFolder', {
+      folderPath: 'imap://user@server/INBOX',
+      force: true,
     });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /Unknown parameter/);


### PR DESCRIPTION
## What

**`refreshFolder(folderPath, timeoutMs)`** — force an IMAP fetch on a folder so the server's current state syncs into Thunderbird's local cache. Handy before `searchMessages` / `getMessage` on an account whose offline copy may be stale.

- Drives the fetch with `folder.getNewMessages(null, urlListener)` and detects completion via an `nsIUrlListener` (`OnStopRunningUrl`).
- Bounded by a one-shot `nsITimer`: `timeoutMs` default 15000, **hard-capped at 25000** to stay under the stdio bridge's 30s request timeout — so a slow server yields a structured `{ error: "refreshFolder timed out…" }` instead of the bridge hard-failing. A resolve-once guard cancels the timer on completion.
- Non-IMAP folders short-circuit to `{ success: true, skipped: "not an IMAP folder" }`.

Returns `{ success, folderPath, totalBefore, totalAfter, newMessages }` on a completed fetch, or a structured `{ error, folderPath }` on timeout / fetch-failure / access-denied. Reuses `getAccessibleFolder` for the per-account access gate.

## Tests

`test/validation.test.cjs` covers the schema; `ALL_TOOLS` updated (structural test passes). Full suite green, `eslint .` 0 errors.

Independent of my other open tool PRs (#145/#148/#149) — branches off `main` directly.
