### PR TITLE
feat(messages): add dryRunCompose (read-only compose preflight, stacked on #125)

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -328,8 +328,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       name: { type: "string", description: "Attachment filename" },
                       contentType: { type: "string", description: "MIME type, e.g. application/pdf" },
                       base64: { type: "string", description: "Base64-encoded file content" },
+                      content: { type: "string", description: "Alias for base64 (accepted for backwards compatibility); base64 takes precedence when both are set" },
                     },
-                    required: ["name", "base64"],
+                    required: ["name"],
                     additionalProperties: false,
                   },
                 ],
@@ -366,8 +367,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       name: { type: "string", description: "Attachment filename" },
                       contentType: { type: "string", description: "MIME type, e.g. application/pdf" },
                       base64: { type: "string", description: "Base64-encoded file content" },
+                      content: { type: "string", description: "Alias for base64 (accepted for backwards compatibility); base64 takes precedence when both are set" },
                     },
-                    required: ["name", "base64"],
+                    required: ["name"],
                     additionalProperties: false,
                   },
                 ],
@@ -614,8 +616,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       name: { type: "string", description: "Attachment filename" },
                       contentType: { type: "string", description: "MIME type, e.g. application/pdf" },
                       base64: { type: "string", description: "Base64-encoded file content" },
+                      content: { type: "string", description: "Alias for base64 (accepted for backwards compatibility); base64 takes precedence when both are set" },
                     },
-                    required: ["name", "base64"],
+                    required: ["name"],
                     additionalProperties: false,
                   },
                 ],
@@ -654,8 +657,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       name: { type: "string", description: "Attachment filename" },
                       contentType: { type: "string", description: "MIME type, e.g. application/pdf" },
                       base64: { type: "string", description: "Base64-encoded file content" },
+                      content: { type: "string", description: "Alias for base64 (accepted for backwards compatibility); base64 takes precedence when both are set" },
                     },
-                    required: ["name", "base64"],
+                    required: ["name"],
                     additionalProperties: false,
                   },
                 ],
@@ -1652,6 +1656,16 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     const file = createLocalFile(entry);
                     if (!file.exists()) {
                       failed.push(entry);
+                      continue;
+                    }
+                    // SECURITY: re-check the *resolved* path. The raw string can
+                    // look benign while pointing at a credential store through a
+                    // symlink (e.g. /tmp/report.pdf -> ~/.ssh/id_rsa). Canonicalize
+                    // (resolves symlinks + . / .. components) and re-run the
+                    // deny-list before reading the file.
+                    try { file.normalize(); } catch (_) { /* keep raw path if normalize fails */ }
+                    if (isSensitiveFilePath(file.path)) {
+                      failed.push(`${entry} (sensitive path blocked)`);
                       continue;
                     }
                     // Size cap mirrors the saved-attachment ceiling and avoids
@@ -6556,6 +6570,13 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 }
                 if (schema.items) {
                   for (let i = 0; i < value.length; i++) {
+                    // Array items are never nullable: validateAgainstSchema
+                    // returns early on null/undefined, so a null item would
+                    // otherwise skip the item schema entirely. Reject explicitly.
+                    if (value[i] === null || value[i] === undefined) {
+                      errors.push(`Parameter '${path}[${i}]' must not be null`);
+                      continue;
+                    }
                     validateAgainstSchema(value[i], schema.items, `${path}[${i}]`, errors);
                   }
                 }

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -72,9 +72,78 @@ const _tempAttachFiles = new Set();
 // WeakSet so entries are collected automatically when the window is destroyed.
 const _claimedComposeWindows = new WeakSet();
 const MAX_BASE64_SIZE = 25 * 1024 * 1024; // 25 MB limit for inline base64 data (encoded)
+// Cap file-path attachments to the same magnitude as saved-message attachments.
+// Prevents an MCP caller from attaching multi-GB files to a single outgoing message.
+const MAX_FILE_PATH_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 // Must be large enough to carry MAX_BASE64_SIZE plus JSON-RPC framing overhead.
 // The httpd.sys.mjs pre-buffer cap uses the same value.
 const MAX_REQUEST_BODY = 32 * 1024 * 1024; // 32 MB limit for incoming HTTP request bodies
+
+// File paths that an MCP caller must never be allowed to attach to outbound
+// mail. Protects against the LLM-confused-deputy chain where attacker-controlled
+// email content prompt-injects an assistant into running
+// sendMail({attachments: ["/home/user/.ssh/id_rsa"], skipReview: true}).
+//
+// Patterns match the path AFTER backslashes are normalized to forward slashes
+// and the whole string is lower-cased, so a single set covers POSIX and Windows.
+// This is a deny-list, not an allow-list -- it intentionally errs toward
+// blocking known-sensitive locations rather than restricting users to a
+// downloads-only sandbox. Extend it as new high-value targets surface.
+const SENSITIVE_ATTACHMENT_PATTERNS = [
+  // SSH / PGP / cloud / kube / docker credentials
+  /\/\.ssh(\/|$)/,
+  /\/\.gnupg(\/|$)/,
+  /\/\.aws(\/|$)/,
+  /\/\.azure(\/|$)/,
+  /\/\.config\/gcloud(\/|$)/,
+  /\/\.kube(\/|$)/,
+  /\/\.docker(\/|$)/,
+  /\/\.netrc$/,
+  /\/\.npmrc$/,
+  /\/\.pypirc$/,
+  // Common key / secret file extensions anywhere on disk
+  /\/id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/,
+  /\.pem$/,
+  /\.pfx$/,
+  /\.p12$/,
+  /\.kdbx$/,
+  /\.key$/,
+  /\.asc$/,
+  /\.gpg$/,
+  // Linux / macOS system directories
+  /^\/etc\//,
+  /^\/proc\//,
+  /^\/sys\//,
+  /^\/root\//,
+  /^\/var\/log\//,
+  /^\/var\/lib\/sudo\//,
+  // macOS keychain locations
+  /\/library\/keychains\//,
+  // Windows system directories
+  /^[a-z]:\/windows\//,
+  /^[a-z]:\/programdata\/microsoft\/(crypto|protect)\//,
+  /\/appdata\/(local|roaming)\/microsoft\/(credentials|crypto|protect|vault)(\/|$)/,
+  // Browser credential stores (Firefox / Chrome / Edge)
+  /\/(logins\.json|key3\.db|key4\.db|cookies(\.sqlite)?|login data)$/,
+  // Thunderbird's own profile (contains the user's entire mail store + prefs).
+  // Linux uses ~/.thunderbird (dot-prefixed), macOS uses ~/Library/Thunderbird,
+  // Windows uses %APPDATA%/Roaming/Thunderbird; cover all three.
+  /\/\.?thunderbird\/profiles?(\/|$)/,
+  /\/library\/thunderbird(\/|$)/,
+  /\/appdata\/roaming\/thunderbird(\/|$)/,
+];
+
+/**
+ * Return true if `attachmentPath` looks like a credential, secret, or system
+ * file that an MCP caller should not be able to attach to outgoing mail.
+ * Path is normalized (backslashes → forward slashes, lower-cased) before
+ * matching so the same pattern set works on POSIX and Windows.
+ */
+function isSensitiveFilePath(attachmentPath) {
+  if (typeof attachmentPath !== "string" || !attachmentPath) return false;
+  const normalized = attachmentPath.replace(/\\/g, "/").toLowerCase();
+  return SENSITIVE_ATTACHMENT_PATTERNS.some(re => re.test(normalized));
+}
 let _tempFileCounter = 0;
 const DEFAULT_MAX_RESULTS = 50;
 const PREF_ALLOWED_ACCOUNTS = "extensions.thunderbird-mcp.allowedAccounts";
@@ -1141,6 +1210,26 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 tmpDir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o700);
               } else if (tmpDir.isSymlink()) {
                 throw new Error("thunderbird-mcp tmp directory is a symlink — refusing to write connection info");
+              } else {
+                // POSIX hardening: on a shared /tmp another local user could
+                // pre-create the directory with group/world bits set, then race
+                // the connection file. The O_EXCL on the file itself blocks a
+                // straight overwrite, but a permissive directory still lets the
+                // attacker read or rename our file. Force perms back to 0o700.
+                // permissions is 0 on platforms that don't expose POSIX modes
+                // (Windows ACLs), so the chmod is a no-op there.
+                try {
+                  const mode = tmpDir.permissions;
+                  if (mode && (mode & 0o077) !== 0) {
+                    try { tmpDir.permissions = 0o700; } catch { /* best-effort */ }
+                    if ((tmpDir.permissions & 0o077) !== 0) {
+                      throw new Error("thunderbird-mcp tmp directory has group/world permissions — refusing to write connection info");
+                    }
+                  }
+                } catch (e) {
+                  if (e && e.message && e.message.startsWith("thunderbird-mcp tmp directory")) throw e;
+                  // ignore: permissions accessor unsupported on this platform
+                }
               }
               const connFile = tmpDir.clone();
               connFile.append("connection.json");
@@ -1229,12 +1318,17 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 
             /**
              * Check if the user has disabled the skipReview shortcut.
-             * When true, send/reply/forward tools must open the review window even
-             * if the caller passed skipReview: true.
+             * When true, send/reply/forward/createEvent/createTask tools must open
+             * the review window/dialog even if the caller passed skipReview: true.
+             *
+             * Default is true: an LLM that reads attacker-controlled email content
+             * can be prompt-injected into invoking sendMail with skipReview, so the
+             * safe default is to require human review. Users can explicitly opt
+             * into silent sends from the options page.
              */
             function isSkipReviewBlocked() {
               try {
-                return Services.prefs.getBoolPref(PREF_BLOCK_SKIPREVIEW, false);
+                return Services.prefs.getBoolPref(PREF_BLOCK_SKIPREVIEW, true);
               } catch {
                 // Fail closed: if we can't read the pref, assume blocked so the
                 // user retains ability to review before send.
@@ -1543,13 +1637,32 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               for (const entry of filePaths) {
                 try {
                   if (typeof entry === "string") {
-                    // File path attachment
-                    const file = createLocalFile(entry);
-                    if (file.exists()) {
-                      descs.push({ url: Services.io.newFileURI(file).spec, name: file.leafName, size: file.fileSize });
-                    } else {
-                      failed.push(entry);
+                    // File path attachment.
+                    //
+                    // SECURITY: reject paths that point at credentials, system
+                    // files, or browser/mail profile data BEFORE touching the
+                    // filesystem. This is the LLM-confused-deputy defense:
+                    // attacker-controlled email content can prompt-inject an
+                    // assistant into calling sendMail with attachments=["/path/to/id_rsa"]
+                    // and we never want that to succeed regardless of skipReview.
+                    if (isSensitiveFilePath(entry)) {
+                      failed.push(`${entry} (sensitive path blocked)`);
+                      continue;
                     }
+                    const file = createLocalFile(entry);
+                    if (!file.exists()) {
+                      failed.push(entry);
+                      continue;
+                    }
+                    // Size cap mirrors the saved-attachment ceiling and avoids
+                    // ballooning outgoing messages when a caller points at a huge file.
+                    let fileSize = 0;
+                    try { fileSize = file.fileSize; } catch { fileSize = 0; }
+                    if (fileSize > MAX_FILE_PATH_ATTACHMENT_BYTES) {
+                      failed.push(`${entry} (exceeds ${MAX_FILE_PATH_ATTACHMENT_BYTES / 1024 / 1024}MB size limit)`);
+                      continue;
+                    }
+                    descs.push({ url: Services.io.newFileURI(file).spec, name: file.leafName, size: fileSize });
                   } else if (entry && typeof entry === "object" && (entry.base64 || entry.content) && entry.name) {
                     // Inline base64 attachment — decode and write to temp file
                     const b64Data = entry.base64 || entry.content;
@@ -3061,6 +3174,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               if (!cal || !CalEvent) {
                 return { error: "Calendar module not available" };
               }
+              if (skipReview && isSkipReviewBlocked()) {
+                return { error: "User preference blocks skipReview. Retry with skipReview: false (or omitted) to open the review dialog instead." };
+              }
               try {
                 const win = Services.wm.getMostRecentWindow("mail:3pane");
                 if (!win && !skipReview) {
@@ -3787,6 +3903,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 
             async function createTask(title, dueDate, calendarId, description, priority, categories, skipReview) {
               if (!cal || !CalTodo) return { error: "Calendar module not available" };
+              if (skipReview && isSkipReviewBlocked()) {
+                return { error: "User preference blocks skipReview. Retry with skipReview: false (or omitted) to open the review dialog instead." };
+              }
               try {
                 let dueDt = null;
                 if (dueDate) {
@@ -6035,13 +6154,18 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             function buildTerms(filter, conditions) {
               for (const cond of conditions) {
                 const term = filter.createTerm();
-                const attribNum = ATTRIB_MAP[cond.attrib] ?? parseInt(cond.attrib);
-                if (isNaN(attribNum)) throw new Error(`Unknown attribute: ${cond.attrib}`);
-                term.attrib = attribNum;
+                // SECURITY: strict allow-list. The previous `?? parseInt(...)`
+                // fallback let callers pass raw nsMsgSearchAttrib enum values that
+                // aren't in ATTRIB_MAP, bypassing the intended named-action set.
+                if (!Object.prototype.hasOwnProperty.call(ATTRIB_MAP, cond.attrib)) {
+                  throw new Error(`Unknown attribute: ${cond.attrib}`);
+                }
+                term.attrib = ATTRIB_MAP[cond.attrib];
 
-                const opNum = OP_MAP[cond.op] ?? parseInt(cond.op);
-                if (isNaN(opNum)) throw new Error(`Unknown operator: ${cond.op}`);
-                term.op = opNum;
+                if (!Object.prototype.hasOwnProperty.call(OP_MAP, cond.op)) {
+                  throw new Error(`Unknown operator: ${cond.op}`);
+                }
+                term.op = OP_MAP[cond.op];
 
                 const value = term.value;
                 value.attrib = term.attrib;
@@ -6057,8 +6181,14 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             function buildActions(filter, actions) {
               for (const act of actions) {
                 const action = filter.createAction();
-                const typeNum = ACTION_MAP[act.type] ?? parseInt(act.type);
-                if (isNaN(typeNum)) throw new Error(`Unknown action type: ${act.type}`);
+                // SECURITY: strict allow-list. The previous `?? parseInt(...)`
+                // fallback accepted any numeric nsMsgFilterAction value, which
+                // would auto-expose new (or legacy) action types we never
+                // intended to surface -- including historic "run program" flavors.
+                if (!Object.prototype.hasOwnProperty.call(ACTION_MAP, act.type)) {
+                  throw new Error(`Unknown action type: ${act.type}`);
+                }
+                const typeNum = ACTION_MAP[act.type];
                 action.type = typeNum;
 
                 if (act.value) {
@@ -6404,6 +6534,85 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
              * and rejects unknown properties.
              * Returns an array of error strings (empty = valid).
              */
+            /**
+             * Walk a JSON-Schema subtree and report any errors against `value`.
+             * Not a full JSON Schema implementation -- intentionally minimal --
+             * but covers the keywords actually used by toolSchemas:
+             *   - type (string/number/integer/boolean/array/object)
+             *   - enum
+             *   - properties + required + additionalProperties (on objects)
+             *   - items (on arrays), including a single-branch oneOf with type
+             *     discrimination, which is how the attachments array is described.
+             * `path` is the dotted property path used in error messages.
+             */
+            function validateAgainstSchema(value, schema, path, errors) {
+              if (!schema || value === undefined || value === null) return;
+
+              const expectedType = schema.type;
+              if (expectedType === "array") {
+                if (!Array.isArray(value)) {
+                  errors.push(`Parameter '${path}' must be an array, got ${typeof value}`);
+                  return;
+                }
+                if (schema.items) {
+                  for (let i = 0; i < value.length; i++) {
+                    validateAgainstSchema(value[i], schema.items, `${path}[${i}]`, errors);
+                  }
+                }
+              } else if (expectedType === "object") {
+                if (typeof value !== "object" || Array.isArray(value)) {
+                  errors.push(`Parameter '${path}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
+                  return;
+                }
+                const nestedProps = schema.properties || {};
+                const nestedRequired = schema.required || [];
+                for (const r of nestedRequired) {
+                  if (value[r] === undefined || value[r] === null) {
+                    errors.push(`Missing required parameter: ${path}.${r}`);
+                  }
+                }
+                for (const [k, v] of Object.entries(value)) {
+                  const has = Object.prototype.hasOwnProperty.call(nestedProps, k);
+                  if (!has) {
+                    if (schema.additionalProperties === false) {
+                      errors.push(`Unknown parameter: ${path}.${k}`);
+                    }
+                    continue;
+                  }
+                  validateAgainstSchema(v, nestedProps[k], `${path}.${k}`, errors);
+                }
+              } else if (expectedType === "integer") {
+                if (typeof value !== "number" || !Number.isInteger(value)) {
+                  errors.push(`Parameter '${path}' must be an integer, got ${typeof value === "number" ? "non-integer number" : typeof value}`);
+                  return;
+                }
+              } else if (expectedType && typeof value !== expectedType) {
+                errors.push(`Parameter '${path}' must be ${expectedType}, got ${typeof value}`);
+                return;
+              }
+
+              // oneOf: accept the value if exactly one branch validates clean.
+              // Used by the attachments array items (string | object).
+              if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+                let matched = 0;
+                for (const branch of schema.oneOf) {
+                  const branchErrors = [];
+                  validateAgainstSchema(value, branch, path, branchErrors);
+                  if (branchErrors.length === 0) matched++;
+                }
+                if (matched === 0) {
+                  errors.push(`Parameter '${path}' did not match any allowed schema variant`);
+                } else if (matched > 1) {
+                  errors.push(`Parameter '${path}' matched more than one schema variant`);
+                }
+              }
+
+              // enum: explicit value allow-list (e.g. bodyFormat).
+              if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+                errors.push(`Parameter '${path}' must be one of ${JSON.stringify(schema.enum)}, got ${JSON.stringify(value)}`);
+              }
+            }
+
             function validateToolArgs(name, args) {
               const tool = buildTools().find(t => t.name === name);
               const schema = tool?.inputSchema;
@@ -6431,30 +6640,17 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 }
                 if (value === undefined || value === null) continue;
 
-                const expectedType = propSchema.type;
-                if (expectedType === "array") {
-                  if (!Array.isArray(value)) {
-                    errors.push(`Parameter '${key}' must be an array, got ${typeof value}`);
-                  } else {
-                    if (propSchema.minItems !== undefined && value.length < propSchema.minItems) {
-                      errors.push(`Parameter '${key}' must contain at least ${propSchema.minItems} item(s)`);
-                    }
-                    if (propSchema.maxItems !== undefined && value.length > propSchema.maxItems) {
-                      errors.push(`Parameter '${key}' must contain at most ${propSchema.maxItems} item(s)`);
-                    }
+                validateAgainstSchema(value, propSchema, key, errors);
+                // minItems/maxItems sit outside validateAgainstSchema (which covers
+                // type/items/object/integer/oneOf/enum); keep the array-length bounds
+                // so the v0.6.0 getMessages-batch caps stay enforced.
+                if (propSchema.type === "array" && Array.isArray(value)) {
+                  if (propSchema.minItems !== undefined && value.length < propSchema.minItems) {
+                    errors.push(`Parameter '${key}' must contain at least ${propSchema.minItems} item(s)`);
                   }
-                } else if (expectedType === "object") {
-                  if (typeof value !== "object" || Array.isArray(value)) {
-                    errors.push(`Parameter '${key}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
+                  if (propSchema.maxItems !== undefined && value.length > propSchema.maxItems) {
+                    errors.push(`Parameter '${key}' must contain at most ${propSchema.maxItems} item(s)`);
                   }
-                } else if (expectedType === "integer") {
-                  // JSON Schema "integer" is a whole number. typeof reports
-                  // "number" for both integers and floats, so check explicitly.
-                  if (typeof value !== "number" || !Number.isInteger(value)) {
-                    errors.push(`Parameter '${key}' must be an integer, got ${typeof value === "number" ? "non-integer number" : typeof value}`);
-                  }
-                } else if (expectedType && typeof value !== expectedType) {
-                  errors.push(`Parameter '${key}' must be ${expectedType}, got ${typeof value}`);
                 }
               }
 
@@ -7058,9 +7254,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         },
 
         getBlockSkipReview: async function() {
-          let blocked = false;
+          let blocked = true;
           try {
-            blocked = Services.prefs.getBoolPref(PREF_BLOCK_SKIPREVIEW, false);
+            blocked = Services.prefs.getBoolPref(PREF_BLOCK_SKIPREVIEW, true);
           } catch { /* ignore */ }
           return { blockSkipReview: blocked };
         },
@@ -7069,11 +7265,9 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
           if (typeof blockSkipReview !== "boolean") {
             return { error: "blockSkipReview must be a boolean" };
           }
-          if (blockSkipReview) {
-            Services.prefs.setBoolPref(PREF_BLOCK_SKIPREVIEW, true);
-          } else {
-            try { Services.prefs.clearUserPref(PREF_BLOCK_SKIPREVIEW); } catch { /* ignore */ }
-          }
+          // Default is true; persist the explicit value either way so the user's
+          // choice survives independent of the default we ship.
+          Services.prefs.setBoolPref(PREF_BLOCK_SKIPREVIEW, blockSkipReview);
           return { success: true, blockSkipReview };
         },
 

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -144,6 +144,25 @@ function isSensitiveFilePath(attachmentPath) {
   const normalized = attachmentPath.replace(/\\/g, "/").toLowerCase();
   return SENSITIVE_ATTACHMENT_PATTERNS.some(re => re.test(normalized));
 }
+
+/**
+ * Collapse CR/LF/NUL runs in a single-line header value to a single space.
+ * Prevents header-injection and keeps a preview/sanitized subject on one line.
+ * Non-string input is returned unchanged. Pure (no I/O).
+ */
+function sanitizeHeaderLine(value) {
+  if (typeof value !== "string") return value;
+  return value.replace(/[\r\n\0]+/g, " ");
+}
+
+/**
+ * Count distinct recipients in a comma-separated address header string.
+ * Comma-splits, trims, drops empties. Pure (no I/O).
+ */
+function countRecipients(s) {
+  if (typeof s !== "string" || !s.trim()) return 0;
+  return s.split(",").map(p => p.trim()).filter(Boolean).length;
+}
 let _tempFileCounter = 0;
 const DEFAULT_MAX_RESULTS = 50;
 const PREF_ALLOWED_ACCOUNTS = "extensions.thunderbird-mcp.allowedAccounts";
@@ -966,6 +985,45 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         description: "Get the current account access control list. Shows which accounts the MCP server can access. Account access is configured by the user in the extension settings page (Tools > Add-ons > Thunderbird MCP > Options) and cannot be changed via MCP tools.",
         inputSchema: { type: "object", properties: {}, required: [] },
       },
+      {
+        name: "dryRunCompose",
+        group: "messages", crud: "read",
+        title: "Dry-Run Compose",
+        description: "Validate compose parameters WITHOUT sending or saving. Resolves the from identity, parses recipient counts, evaluates every attachment through the same path / size / deny-list pipeline that sendMail uses, and reports the rendered subject (after header sanitization). Useful for an agent that wants to self-check a compose call before triggering the review window or skipReview send.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            to: { type: "string", description: "Recipient email address" },
+            subject: { type: "string", description: "Email subject line" },
+            body: { type: "string", description: "Email body text (length is reported back; content is not echoed)" },
+            cc: { type: "string", description: "CC recipients (comma-separated)" },
+            bcc: { type: "string", description: "BCC recipients (comma-separated)" },
+            isHtml: { type: "boolean", description: "Treat body as HTML (default: false)" },
+            from: { type: "string", description: "Sender identity (email address or identity ID)" },
+            attachments: {
+              type: "array",
+              description: "Attachments to evaluate (same shape as sendMail). Each entry is checked but neither read nor copied; only path/size/deny-list status is returned.",
+              items: {
+                oneOf: [
+                  { type: "string", description: "Absolute file path to attach" },
+                  {
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                      contentType: { type: "string" },
+                      base64: { type: "string" },
+                      content: { type: "string", description: "Alias for base64 (accepted for backwards compatibility); base64 takes precedence when both are set" },
+                    },
+                    required: ["name"],
+                    additionalProperties: false,
+                  },
+                ],
+              },
+            },
+          },
+          required: ["to", "subject", "body"],
+        },
+      },
       ];
     }
 
@@ -1624,6 +1682,121 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             /** Returns user-visible tag keywords from a message header, filtering out internal IMAP flags. */
             function getUserTags(msgHdr) {
               return (msgHdr.getStringProperty("keywords") || "").split(/\s+/).filter(k => k && !INTERNAL_KEYWORDS.has(k.toLowerCase()));
+            }
+
+            /**
+             * Read-only preview of a compose call. Resolves the from identity,
+             * counts recipients, sanitizes the subject, and evaluates each
+             * attachment through the SAME path / size / deny-list checks that
+             * sendMail uses -- but NEVER sends, saves a draft, opens a compose
+             * window, decodes/copies attachment bytes, or writes any temp file.
+             * Returns a plain object describing what would happen; it never
+             * throws to the caller and never returns an {error} shape.
+             */
+            function dryRunCompose(to, subject, body, cc, bcc, isHtml, from, attachments) {
+              const result = {
+                wouldSucceed: true,
+                blockers: [],
+                resolvedIdentity: null,
+                isHtml: !!isHtml,
+                subjectAfterSanitization: sanitizeHeaderLine(subject || ""),
+                bodyLength: typeof body === "string" ? body.length : 0,
+                recipients: {
+                  to: countRecipients(to),
+                  cc: countRecipients(cc),
+                  bcc: countRecipients(bcc),
+                },
+                attachments: [],
+                skipReviewBlocked: isSkipReviewBlocked(),
+              };
+
+              // Resolve identity through the same accessible-account path used
+              // by composeMail, but never fall back silently to the default --
+              // if `from` is set and doesn't match, surface the same error
+              // sendMail would return.
+              try {
+                if (from) {
+                  const identity = findIdentity(from);
+                  if (!identity) {
+                    result.blockers.push(`from identity not found or not accessible: ${from}`);
+                    result.wouldSucceed = false;
+                  } else {
+                    result.resolvedIdentity = {
+                      key: identity.key,
+                      email: identity.email,
+                      fullName: identity.fullName || null,
+                    };
+                  }
+                } else {
+                  // Default identity preview: first accessible identity.
+                  const accounts = getAccessibleAccounts();
+                  const firstIdentity = accounts[0] && accounts[0].defaultIdentity;
+                  if (firstIdentity) {
+                    result.resolvedIdentity = {
+                      key: firstIdentity.key,
+                      email: firstIdentity.email,
+                      fullName: firstIdentity.fullName || null,
+                      isDefault: true,
+                    };
+                  }
+                }
+              } catch (e) {
+                result.blockers.push(`identity resolution failed: ${e.message || e}`);
+                result.wouldSucceed = false;
+              }
+
+              // Per-attachment evaluation. Mirrors filePathsToAttachDescs but
+              // never copies / decodes / writes anything; only reports verdict.
+              if (Array.isArray(attachments)) {
+                for (const entry of attachments) {
+                  const att = { kind: null, name: null, status: "ok", reason: null, size: null };
+                  if (typeof entry === "string") {
+                    att.kind = "path";
+                    att.name = entry;
+                    if (isSensitiveFilePath(entry)) {
+                      att.status = "blocked";
+                      att.reason = "sensitive path";
+                    } else {
+                      try {
+                        const file = createLocalFile(entry);
+                        if (!file.exists()) {
+                          att.status = "missing";
+                          att.reason = "file does not exist";
+                        } else {
+                          try { att.size = file.fileSize; } catch { att.size = null; }
+                          if (att.size !== null && att.size > MAX_FILE_PATH_ATTACHMENT_BYTES) {
+                            att.status = "blocked";
+                            att.reason = `exceeds ${MAX_FILE_PATH_ATTACHMENT_BYTES / 1024 / 1024}MB cap`;
+                          }
+                        }
+                      } catch (e) {
+                        att.status = "error";
+                        att.reason = e.message || String(e);
+                      }
+                    }
+                  } else if (entry && typeof entry === "object" && (entry.base64 || entry.content) && entry.name) {
+                    att.kind = "inline";
+                    att.name = entry.name;
+                    const b64 = entry.base64 || entry.content;
+                    att.size = typeof b64 === "string" ? Math.floor((b64.length * 3) / 4) : null;
+                    if (typeof b64 === "string" && b64.length > MAX_BASE64_SIZE) {
+                      att.status = "blocked";
+                      att.reason = `inline base64 exceeds ${MAX_BASE64_SIZE / 1024 / 1024}MB`;
+                    }
+                  } else {
+                    att.kind = "invalid";
+                    att.name = typeof entry === "object" ? JSON.stringify(entry).slice(0, 80) : String(entry);
+                    att.status = "blocked";
+                    att.reason = "neither a file path nor an inline {name, base64} object";
+                  }
+                  if (att.status !== "ok") {
+                    result.wouldSucceed = false;
+                  }
+                  result.attachments.push(att);
+                }
+              }
+
+              return result;
             }
 
             /**
@@ -6800,6 +6973,8 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   return applyFilters(args.accountId, args.folderPath);
                 case "getAccountAccess":
                   return getAccountAccess();
+                case "dryRunCompose":
+                  return dryRunCompose(args.to, args.subject, args.body, args.cc, args.bcc, args.isHtml, args.from, args.attachments);
                 default:
                   throw new Error(`Unknown tool: ${name}`);
               }

--- a/test/tool-access.test.cjs
+++ b/test/tool-access.test.cjs
@@ -85,6 +85,7 @@ const ALL_TOOLS = [
   { name: "updateMessage", group: "messages", crud: "update" },
   { name: "deleteMessages", group: "messages", crud: "delete" },
   { name: "saveDraft", group: "messages", crud: "create" },
+  { name: "dryRunCompose", group: "messages", crud: "read" },
   { name: "createFolder", group: "folders", crud: "create" },
   { name: "renameFolder", group: "folders", crud: "update" },
   { name: "moveFolder", group: "folders", crud: "update" },

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -16,9 +16,74 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
 /**
- * Exact copy of validateToolArgs from api.js.
+ * Exact copy of validateToolArgs / validateAgainstSchema from api.js.
  * Kept in sync manually — if the logic in api.js changes, update here too.
  */
+function validateAgainstSchema(value, schema, path, errors) {
+  if (!schema || value === undefined || value === null) return;
+
+  const expectedType = schema.type;
+  if (expectedType === "array") {
+    if (!Array.isArray(value)) {
+      errors.push(`Parameter '${path}' must be an array, got ${typeof value}`);
+      return;
+    }
+    if (schema.items) {
+      for (let i = 0; i < value.length; i++) {
+        validateAgainstSchema(value[i], schema.items, `${path}[${i}]`, errors);
+      }
+    }
+  } else if (expectedType === "object") {
+    if (typeof value !== "object" || Array.isArray(value)) {
+      errors.push(`Parameter '${path}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
+      return;
+    }
+    const nestedProps = schema.properties || {};
+    const nestedRequired = schema.required || [];
+    for (const r of nestedRequired) {
+      if (value[r] === undefined || value[r] === null) {
+        errors.push(`Missing required parameter: ${path}.${r}`);
+      }
+    }
+    for (const [k, v] of Object.entries(value)) {
+      const has = Object.prototype.hasOwnProperty.call(nestedProps, k);
+      if (!has) {
+        if (schema.additionalProperties === false) {
+          errors.push(`Unknown parameter: ${path}.${k}`);
+        }
+        continue;
+      }
+      validateAgainstSchema(v, nestedProps[k], `${path}.${k}`, errors);
+    }
+  } else if (expectedType === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      errors.push(`Parameter '${path}' must be an integer, got ${typeof value === "number" ? "non-integer number" : typeof value}`);
+      return;
+    }
+  } else if (expectedType && typeof value !== expectedType) {
+    errors.push(`Parameter '${path}' must be ${expectedType}, got ${typeof value}`);
+    return;
+  }
+
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+    let matched = 0;
+    for (const branch of schema.oneOf) {
+      const branchErrors = [];
+      validateAgainstSchema(value, branch, path, branchErrors);
+      if (branchErrors.length === 0) matched++;
+    }
+    if (matched === 0) {
+      errors.push(`Parameter '${path}' did not match any allowed schema variant`);
+    } else if (matched > 1) {
+      errors.push(`Parameter '${path}' matched more than one schema variant`);
+    }
+  }
+
+  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+    errors.push(`Parameter '${path}' must be one of ${JSON.stringify(schema.enum)}, got ${JSON.stringify(value)}`);
+  }
+}
+
 function createValidator(tools) {
   const toolSchemas = Object.create(null);
   for (const t of tools) {
@@ -47,24 +112,16 @@ function createValidator(tools) {
       }
       if (value === undefined || value === null) continue;
 
-      const expectedType = propSchema.type;
-      if (expectedType === "array") {
-        if (!Array.isArray(value)) {
-          errors.push(`Parameter '${key}' must be an array, got ${typeof value}`);
-        } else {
-          if (propSchema.minItems !== undefined && value.length < propSchema.minItems) {
-            errors.push(`Parameter '${key}' must contain at least ${propSchema.minItems} item(s)`);
-          }
-          if (propSchema.maxItems !== undefined && value.length > propSchema.maxItems) {
-            errors.push(`Parameter '${key}' must contain at most ${propSchema.maxItems} item(s)`);
-          }
+      validateAgainstSchema(value, propSchema, key, errors);
+      // Array length bounds (minItems/maxItems) sit outside validateAgainstSchema;
+      // mirror the production validateToolArgs so getMessages-batch caps are tested.
+      if (propSchema.type === "array" && Array.isArray(value)) {
+        if (propSchema.minItems !== undefined && value.length < propSchema.minItems) {
+          errors.push(`Parameter '${key}' must contain at least ${propSchema.minItems} item(s)`);
         }
-      } else if (expectedType === "object") {
-        if (typeof value !== "object" || Array.isArray(value)) {
-          errors.push(`Parameter '${key}' must be an object, got ${Array.isArray(value) ? "array" : typeof value}`);
+        if (propSchema.maxItems !== undefined && value.length > propSchema.maxItems) {
+          errors.push(`Parameter '${key}' must contain at most ${propSchema.maxItems} item(s)`);
         }
-      } else if (expectedType && typeof value !== expectedType) {
-        errors.push(`Parameter '${key}' must be ${expectedType}, got ${typeof value}`);
       }
     }
 
@@ -528,5 +585,361 @@ describe('Validation: getMessages batch size', () => {
     });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /at most 10/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for the recursive validator additions: enum, oneOf branches, nested
+// objects with additionalProperties:false, integer type checks. These cover
+// schema keywords the previous shallow validator silently ignored.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const richValidator = createValidator([
+  {
+    name: 'getMessage',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        messageId: { type: 'string' },
+        folderPath: { type: 'string' },
+        bodyFormat: { type: 'string', enum: ['markdown', 'text', 'html'] },
+        rawSource: { type: 'boolean' },
+      },
+      required: ['messageId', 'folderPath'],
+    },
+  },
+  {
+    name: 'sendMail',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string' },
+        subject: { type: 'string' },
+        body: { type: 'string' },
+        attachments: {
+          type: 'array',
+          items: {
+            oneOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  contentType: { type: 'string' },
+                  base64: { type: 'string' },
+                },
+                required: ['name', 'base64'],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+      },
+      required: ['to', 'subject', 'body'],
+    },
+  },
+  {
+    name: 'createTask',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        priority: { type: 'integer' },
+      },
+      required: ['title'],
+    },
+  },
+]);
+
+describe('Validator: enum enforcement', () => {
+  it('accepts an enum value that is in the list', () => {
+    const errors = richValidator('getMessage', {
+      messageId: 'm-1',
+      folderPath: 'imap://x/INBOX',
+      bodyFormat: 'markdown',
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects an enum value that is not in the list', () => {
+    const errors = richValidator('getMessage', {
+      messageId: 'm-1',
+      folderPath: 'imap://x/INBOX',
+      bodyFormat: 'docx',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be one of/);
+    assert.match(errors[0], /bodyFormat/);
+  });
+
+  it('enum check still rejects when string type is satisfied but value is off-list', () => {
+    const errors = richValidator('getMessage', {
+      messageId: 'm-1',
+      folderPath: 'imap://x/INBOX',
+      bodyFormat: 'Markdown', // wrong case
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be one of/);
+  });
+});
+
+describe('Validator: oneOf items (attachments)', () => {
+  it('accepts pure file-path strings', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: ['/tmp/a.txt', '/tmp/b.pdf'],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts well-formed inline base64 objects', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: [{ name: 'a.txt', base64: 'aGk=' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects attachment objects missing required fields', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: [{ contentType: 'application/pdf' }],
+    });
+    // both branches fail (string branch on type, object branch on missing
+    // required), so oneOf records "did not match any allowed variant"
+    assert.ok(errors.some(e => /did not match any allowed schema variant/.test(e)),
+      `expected oneOf failure, got: ${JSON.stringify(errors)}`);
+  });
+
+  it('rejects attachment objects with extra properties (additionalProperties:false)', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: [{ name: 'a.txt', base64: 'aGk=', evil: '../../../etc/passwd' }],
+    });
+    assert.ok(errors.some(e => /did not match any allowed schema variant/.test(e)),
+      `expected oneOf failure when extra props present, got: ${JSON.stringify(errors)}`);
+  });
+
+  it('rejects array entries that are neither strings nor valid objects (e.g. numbers)', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: [123],
+    });
+    assert.ok(errors.some(e => /did not match any allowed schema variant/.test(e)));
+  });
+
+  it('flags the failing index in the error path', () => {
+    const errors = richValidator('sendMail', {
+      to: 'a@b.c',
+      subject: 's',
+      body: 'b',
+      attachments: ['/tmp/ok.txt', 123, '/tmp/also-ok.txt'],
+    });
+    assert.ok(errors.some(e => /attachments\[1\]/.test(e)),
+      `expected attachments[1] path, got: ${JSON.stringify(errors)}`);
+  });
+});
+
+describe('Validator: integer type', () => {
+  it('accepts whole numbers for integer fields', () => {
+    const errors = richValidator('createTask', { title: 't', priority: 5 });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects floats for integer fields', () => {
+    const errors = richValidator('createTask', { title: 't', priority: 1.5 });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an integer/);
+  });
+
+  it('rejects numeric strings for integer fields (no auto-coerce here)', () => {
+    const errors = richValidator('createTask', { title: 't', priority: '5' });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an integer/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isSensitiveFilePath: deny-list defending against the LLM-confused-deputy
+// chain (attacker email content → assistant calls sendMail with sensitive
+// attachment path). Implementation mirrors api.js; tests run cross-platform
+// against the normalized (lower-cased, forward-slash) match form.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SENSITIVE_ATTACHMENT_PATTERNS = [
+  /\/\.ssh(\/|$)/,
+  /\/\.gnupg(\/|$)/,
+  /\/\.aws(\/|$)/,
+  /\/\.azure(\/|$)/,
+  /\/\.config\/gcloud(\/|$)/,
+  /\/\.kube(\/|$)/,
+  /\/\.docker(\/|$)/,
+  /\/\.netrc$/,
+  /\/\.npmrc$/,
+  /\/\.pypirc$/,
+  /\/id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/,
+  /\.pem$/,
+  /\.pfx$/,
+  /\.p12$/,
+  /\.kdbx$/,
+  /\.key$/,
+  /\.asc$/,
+  /\.gpg$/,
+  /^\/etc\//,
+  /^\/proc\//,
+  /^\/sys\//,
+  /^\/root\//,
+  /^\/var\/log\//,
+  /^\/var\/lib\/sudo\//,
+  /\/library\/keychains\//,
+  /^[a-z]:\/windows\//,
+  /^[a-z]:\/programdata\/microsoft\/(crypto|protect)\//,
+  /\/appdata\/(local|roaming)\/microsoft\/(credentials|crypto|protect|vault)(\/|$)/,
+  /\/(logins\.json|key3\.db|key4\.db|cookies(\.sqlite)?|login data)$/,
+  /\/\.?thunderbird\/profiles?(\/|$)/,
+  /\/library\/thunderbird(\/|$)/,
+  /\/appdata\/roaming\/thunderbird(\/|$)/,
+];
+
+function isSensitiveFilePath(attachmentPath) {
+  if (typeof attachmentPath !== 'string' || !attachmentPath) return false;
+  const normalized = attachmentPath.replace(/\\/g, '/').toLowerCase();
+  return SENSITIVE_ATTACHMENT_PATTERNS.some(re => re.test(normalized));
+}
+
+describe('isSensitiveFilePath: credential and key files', () => {
+  it('blocks SSH private keys in ~/.ssh/', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.ssh/id_rsa'), true);
+    assert.equal(isSensitiveFilePath('/Users/jordan/.ssh/id_ed25519'), true);
+    assert.equal(isSensitiveFilePath('C:\\Users\\jordan\\.ssh\\id_rsa'), true);
+  });
+
+  it('blocks SSH public keys (still sensitive, contains fingerprint info)', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.ssh/id_rsa.pub'), true);
+  });
+
+  it('blocks the SSH directory listing itself', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.ssh'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.ssh/'), true);
+  });
+
+  it('blocks GnuPG, AWS, Azure, GCloud, kube, docker config dirs', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.gnupg/secring.gpg'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.aws/credentials'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.azure/accessTokens.json'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.config/gcloud/credentials.db'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.kube/config'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.docker/config.json'), true);
+  });
+
+  it('blocks .netrc / .npmrc / .pypirc credential files', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.netrc'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.npmrc'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.pypirc'), true);
+  });
+
+  it('blocks PEM/PFX/P12/KDBX/KEY/ASC/GPG files anywhere on disk', () => {
+    assert.equal(isSensitiveFilePath('/tmp/server.pem'), true);
+    assert.equal(isSensitiveFilePath('/home/user/wildcard.pfx'), true);
+    assert.equal(isSensitiveFilePath('/data/cert.p12'), true);
+    assert.equal(isSensitiveFilePath('/Users/x/Passwords.kdbx'), true);
+    assert.equal(isSensitiveFilePath('/etc/ssl/private.key'), true);
+    assert.equal(isSensitiveFilePath('/home/user/key.asc'), true);
+    assert.equal(isSensitiveFilePath('/home/user/secret.gpg'), true);
+  });
+});
+
+describe('isSensitiveFilePath: system directories', () => {
+  it('blocks Linux/macOS system dirs', () => {
+    assert.equal(isSensitiveFilePath('/etc/shadow'), true);
+    assert.equal(isSensitiveFilePath('/etc/passwd'), true);
+    assert.equal(isSensitiveFilePath('/proc/self/environ'), true);
+    assert.equal(isSensitiveFilePath('/sys/class/net/eth0/address'), true);
+    assert.equal(isSensitiveFilePath('/root/.bash_history'), true);
+    assert.equal(isSensitiveFilePath('/var/log/auth.log'), true);
+    assert.equal(isSensitiveFilePath('/var/lib/sudo/lectured/user'), true);
+  });
+
+  it('blocks macOS keychains', () => {
+    assert.equal(isSensitiveFilePath('/Users/x/Library/Keychains/login.keychain-db'), true);
+  });
+
+  it('blocks Windows system dirs (forward and back slashes)', () => {
+    assert.equal(isSensitiveFilePath('C:\\Windows\\System32\\config\\SAM'), true);
+    assert.equal(isSensitiveFilePath('C:/Windows/System32/config/SAM'), true);
+    assert.equal(isSensitiveFilePath('D:/Windows/System32/notepad.exe'), true);
+  });
+
+  it('blocks Windows DPAPI / credential vault locations', () => {
+    assert.equal(isSensitiveFilePath('C:\\ProgramData\\Microsoft\\Crypto\\RSA\\MachineKeys\\x'), true);
+    assert.equal(isSensitiveFilePath('C:\\Users\\jordan\\AppData\\Local\\Microsoft\\Credentials\\x'), true);
+    assert.equal(isSensitiveFilePath('C:\\Users\\jordan\\AppData\\Roaming\\Microsoft\\Vault'), true);
+  });
+});
+
+describe('isSensitiveFilePath: browser and mail data', () => {
+  it('blocks browser credential stores', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.mozilla/firefox/abc.default/logins.json'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.mozilla/firefox/abc.default/key4.db'), true);
+    assert.equal(isSensitiveFilePath('/home/user/.config/google-chrome/Default/Cookies'), true);
+    assert.equal(
+      isSensitiveFilePath('C:\\Users\\x\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Login Data'),
+      true
+    );
+  });
+
+  it('blocks Thunderbird profile directories on all platforms', () => {
+    assert.equal(isSensitiveFilePath('/home/user/.thunderbird/profiles/abc.default/Mail/Local Folders'), true);
+    assert.equal(isSensitiveFilePath('/Users/x/Library/Thunderbird/Profiles/abc/INBOX'), true);
+    assert.equal(isSensitiveFilePath('C:\\Users\\jordan\\AppData\\Roaming\\Thunderbird\\Profiles\\abc'), true);
+  });
+});
+
+describe('isSensitiveFilePath: benign paths pass through', () => {
+  it('allows typical user documents and downloads', () => {
+    assert.equal(isSensitiveFilePath('/home/user/Documents/report.pdf'), false);
+    assert.equal(isSensitiveFilePath('/home/user/Downloads/photo.jpg'), false);
+    assert.equal(isSensitiveFilePath('C:\\Users\\jordan\\Downloads\\invoice.xlsx'), false);
+    assert.equal(isSensitiveFilePath('/tmp/scratch.txt'), false);
+  });
+
+  it('allows files whose names merely contain substrings of patterns', () => {
+    // "ssh" inside a filename is not the /.ssh/ directory boundary
+    assert.equal(isSensitiveFilePath('/home/user/notes/ssh-cheatsheet.md'), false);
+    // .pemphigus is not .pem
+    assert.equal(isSensitiveFilePath('/home/user/medical/pemphigus.txt'), false);
+    // "etc" inside a path that doesn't start at /etc/
+    assert.equal(isSensitiveFilePath('/home/user/etc-notes.md'), false);
+  });
+
+  it('returns false on non-string / empty input rather than throwing', () => {
+    assert.equal(isSensitiveFilePath(''), false);
+    assert.equal(isSensitiveFilePath(null), false);
+    assert.equal(isSensitiveFilePath(undefined), false);
+    assert.equal(isSensitiveFilePath(123), false);
+    assert.equal(isSensitiveFilePath({}), false);
+  });
+});
+
+describe('isSensitiveFilePath: case insensitivity and slash normalization', () => {
+  it('matches regardless of letter case', () => {
+    assert.equal(isSensitiveFilePath('/HOME/USER/.SSH/ID_RSA'), true);
+    assert.equal(isSensitiveFilePath('/Etc/Shadow'), true);
+    assert.equal(isSensitiveFilePath('C:\\WINDOWS\\system32\\drivers'), true);
+  });
+
+  it('treats backslashes and forward slashes as equivalent boundaries', () => {
+    assert.equal(isSensitiveFilePath('C:/Users/x/.ssh/id_rsa'), true);
+    assert.equal(isSensitiveFilePath('C:\\Users\\x\\.ssh\\id_rsa'), true);
   });
 });

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -299,6 +299,41 @@ const sampleTools = [
     name: "getAccountAccess",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
+  {
+    name: "dryRunCompose",
+    inputSchema: {
+      type: "object",
+      properties: {
+        to: { type: "string" },
+        subject: { type: "string" },
+        body: { type: "string" },
+        cc: { type: "string" },
+        bcc: { type: "string" },
+        isHtml: { type: "boolean" },
+        from: { type: "string" },
+        attachments: {
+          type: "array",
+          items: {
+            oneOf: [
+              { type: "string" },
+              {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  contentType: { type: "string" },
+                  base64: { type: "string" },
+                  content: { type: "string" },
+                },
+                required: ["name"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+      },
+      required: ["to", "subject", "body"],
+    },
+  },
 ];
 
 const validate = createValidator(sampleTools);
@@ -1033,5 +1068,115 @@ describe('isSensitiveFilePath: case insensitivity and slash normalization', () =
   it('treats backslashes and forward slashes as equivalent boundaries', () => {
     assert.equal(isSensitiveFilePath('C:/Users/x/.ssh/id_rsa'), true);
     assert.equal(isSensitiveFilePath('C:\\Users\\x\\.ssh\\id_rsa'), true);
+  });
+});
+
+describe('Validation: dryRunCompose schema', () => {
+  it('accepts minimal required fields (to, subject, body)', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello there',
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts all optional scalar fields', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      cc: 'bob@example.com',
+      bcc: 'carol@example.com',
+      isHtml: true,
+      from: 'me@example.com',
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects when required field is missing', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Missing required parameter: body/);
+  });
+
+  it('rejects isHtml as string', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      isHtml: 'true',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be boolean/);
+  });
+
+  it('rejects unknown top-level parameter (no skipReview on dry run)', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      skipReview: true,
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Unknown parameter: skipReview/);
+  });
+
+  it('accepts attachments as array of file-path strings', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      attachments: ['/home/user/report.pdf', '/tmp/data.csv'],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts inline attachment with required name + base64', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      attachments: [{ name: 'a.txt', base64: 'aGVsbG8=' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  // Only `name` is required at the schema level (consistent with the other
+  // compose tools); an entry with neither base64 nor content passes validation
+  // and the handler reports it as an invalid attachment, rather than the
+  // validator rejecting the whole call.
+  it('accepts inline {name} at the schema level (handler reports it invalid)', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      attachments: [{ name: 'a.txt' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts inline attachment using the content alias for base64', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      attachments: [{ name: 'a.txt', content: 'aGVsbG8=' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects attachments as a non-array', () => {
+    const errors = validate('dryRunCompose', {
+      to: 'alice@example.com',
+      subject: 'hi',
+      body: 'hello',
+      attachments: '/home/user/report.pdf',
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must be an array/);
   });
 });

--- a/test/validation.test.cjs
+++ b/test/validation.test.cjs
@@ -30,6 +30,10 @@ function validateAgainstSchema(value, schema, path, errors) {
     }
     if (schema.items) {
       for (let i = 0; i < value.length; i++) {
+        if (value[i] === null || value[i] === undefined) {
+          errors.push(`Parameter '${path}[${i}]' must not be null`);
+          continue;
+        }
         validateAgainstSchema(value[i], schema.items, `${path}[${i}]`, errors);
       }
     }
@@ -155,7 +159,25 @@ const sampleTools = [
         to: { type: "string" },
         subject: { type: "string" },
         body: { type: "string" },
-        attachments: { type: "array", items: { oneOf: [{ type: "string" }, { type: "object" }] } },
+        attachments: {
+          type: "array",
+          items: {
+            oneOf: [
+              { type: "string" },
+              {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  contentType: { type: "string" },
+                  base64: { type: "string" },
+                  content: { type: "string" },
+                },
+                required: ["name"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
       },
       required: ["to", "subject", "body"],
     },
@@ -480,6 +502,76 @@ describe('Validation: attachment sending', () => {
     });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /must be an array/);
+  });
+
+  // Regression: the runtime accepts `content` as an alias for `base64`
+  // (entry.base64 || entry.content). Validation must not reject {name, content}.
+  it('accepts inline attachment using `content` as a base64 alias', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [{ name: 'file.pdf', content: 'AAAA' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  // Regression: contentType is optional at runtime; {name, base64} must pass.
+  it('accepts inline attachment with base64 and no contentType', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [{ name: 'file.pdf', base64: 'AAAA' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  // base64 + content together is accepted (runtime lets base64 win); validation
+  // must mirror that and not reject the redundant shape.
+  it('accepts inline attachment with both base64 and content set', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [{ name: 'file.pdf', base64: 'AAAA', content: 'BBBB' }],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects inline attachment missing name', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [{ base64: 'AAAA' }],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /did not match any allowed schema variant/);
+  });
+
+  it('rejects inline attachment with unknown property', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [{ name: 'file.pdf', base64: 'AAAA', evil: 'x' }],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /did not match any allowed schema variant/);
+  });
+
+  // Regression: validateAgainstSchema returns early on null, so a null array
+  // item used to skip the item schema entirely. Must be rejected explicitly.
+  it('rejects a null attachment item', () => {
+    const errors = validate('sendMail', {
+      to: 'user@example.com',
+      subject: 'test',
+      body: 'hello',
+      attachments: [null],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /must not be null/);
   });
 });
 


### PR DESCRIPTION
> **Stacked on #125** — it reuses the deny-list / recipient-count helpers from that PR (`isSensitiveFilePath`, `countRecipients`, `MAX_FILE_PATH_ATTACHMENT_BYTES`). Please review/merge #125 first; its commits drop out of this diff once it lands.

## What

**`dryRunCompose(to, subject, body, cc, bcc, isHtml, from, attachments)`** — validate compose parameters **without any side effect**: it does not send, save a draft, open a compose window, write temp files, or copy/decode attachment bytes. A pure read-only preflight for agents that want to know "would this send cleanly?" before committing.

Returns a structured report:
- `wouldSucceed` (roll-up), `blockers[]` (identity/resolution failures)
- `resolvedIdentity` (resolved `from`, or the default-identity preview)
- `subjectAfterSanitization`, `bodyLength` (content is **not** echoed), `recipients: {to, cc, bcc}` counts
- per-attachment verdict `{ kind, name, status: ok|blocked|missing|error, reason, size }` — file paths are checked against the sensitive-path deny-list and the 50 MB cap via a **stat-only** `nsIFile` (never opened/read/normalized); inline entries' decoded size is **estimated arithmetically** and checked against the 25 MB cap (base64 is never decoded)
- `skipReviewBlocked` pref snapshot (reported only)

## No side effects (verified)

Deliberately does **not** call the `filePathsToAttachDescs` path (which writes temp files / builds file URIs). The attachment loop only stats paths and arithmetic-estimates inline sizes. Reviewed adversarially specifically to disprove any send/save/window/temp-file/network effect.

## Tests

`test/validation.test.cjs` covers the schema (incl. the content-alias on inline attachments, consistent with the other compose tools); `ALL_TOOLS` updated. Full suite green, `eslint .` 0 errors.
