### PR TITLE
v0.7.2: connection self-heal (#143), Docker Host-header fallback (#154), TB compat CI (#153)

### DIFF
--- a/.github/workflows/tb-compat-test.yml
+++ b/.github/workflows/tb-compat-test.yml
@@ -1,0 +1,303 @@
+name: Thunderbird Compatibility Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - "extension/**"
+      - "package.json"
+      - "scripts/build.sh"
+      - ".github/workflows/tb-compat-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  compat-test:
+    name: TB compat (${{ matrix.channel }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, beta]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+
+      - name: Load extension in Thunderbird
+        shell: bash
+        env:
+          EXIT_ON_FAILURE: "true"
+          TB_CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -euo pipefail
+
+          status="success"
+          failure_kind=""
+          message=""
+          tb_version=""
+          ext_active=""
+          ext_app_disabled=""
+          profile_dir=""
+          result_file="${RUNNER_TEMP}/tb-compat-${TB_CHANNEL}.json"
+          tb_log="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}.log"
+
+          write_result() {
+            RESULT_STATUS="$status" \
+            RESULT_FAILURE_KIND="$failure_kind" \
+            RESULT_MESSAGE="$message" \
+            RESULT_TB_CHANNEL="$TB_CHANNEL" \
+            RESULT_TB_VERSION="$tb_version" \
+            RESULT_EXT_ACTIVE="$ext_active" \
+            RESULT_EXT_APP_DISABLED="$ext_app_disabled" \
+            RESULT_PROFILE_DIR="$profile_dir" \
+            RESULT_LOG_FILE="$tb_log" \
+            RESULT_FILE="$result_file" \
+            node <<'NODE'
+          const fs = require('fs');
+
+          function optionalBool(value) {
+            if (value === 'true') return true;
+            if (value === 'false') return false;
+            return null;
+          }
+
+          const result = {
+            channel: process.env.RESULT_TB_CHANNEL,
+            status: process.env.RESULT_STATUS,
+            failureKind: process.env.RESULT_FAILURE_KIND || null,
+            message: process.env.RESULT_MESSAGE || null,
+            thunderbirdVersion: process.env.RESULT_TB_VERSION || null,
+            active: optionalBool(process.env.RESULT_EXT_ACTIVE || ''),
+            appDisabled: optionalBool(process.env.RESULT_EXT_APP_DISABLED || ''),
+            profileDir: process.env.RESULT_PROFILE_DIR || null,
+            logFile: process.env.RESULT_LOG_FILE || null,
+          };
+
+          fs.writeFileSync(process.env.RESULT_FILE, JSON.stringify(result, null, 2) + '\n');
+          NODE
+          }
+
+          finish() {
+            write_result
+            {
+              echo "### Thunderbird compatibility (${TB_CHANNEL})"
+              echo ""
+              echo "- Status: ${status}"
+              if [ -n "$tb_version" ]; then echo "- Thunderbird: ${tb_version}"; fi
+              if [ -n "$ext_app_disabled" ]; then echo "- appDisabled: ${ext_app_disabled}"; fi
+              if [ -n "$ext_active" ]; then echo "- active: ${ext_active}"; fi
+              if [ -n "$message" ]; then echo "- Message: ${message}"; fi
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$status" = "success" ]; then
+              exit 0
+            fi
+            if [ "${EXIT_ON_FAILURE:-true}" = "true" ]; then
+              exit 1
+            fi
+            exit 0
+          }
+
+          fail_infra() {
+            status="infra_failure"
+            failure_kind="infra"
+            message="$1"
+            echo "::error::${message}"
+            finish
+          }
+
+          fail_load() {
+            status="load_failure"
+            failure_kind="load"
+            message="$1"
+            echo "::error::${message}"
+            finish
+          }
+
+          sudo apt-get update -qq || fail_infra "apt-get update failed"
+          sudo apt-get install -y -qq bzip2 curl jq libdbus-glib-1-2 libgtk-3-0 libx11-xcb1 libxt6 xvfb xz-utils zip \
+            || fail_infra "failed to install Thunderbird runtime dependencies"
+          if ! ldconfig -p | grep -q 'libasound.so.2'; then
+            sudo apt-get install -y -qq libasound2t64 \
+              || sudo apt-get install -y -qq libasound2 \
+              || fail_infra "failed to install libasound"
+          fi
+
+          bash scripts/build.sh || fail_infra "scripts/build.sh failed"
+          [ -f dist/thunderbird-mcp.xpi ] || fail_infra "dist/thunderbird-mcp.xpi was not produced"
+
+          case "$TB_CHANNEL" in
+            stable) version_key="LATEST_THUNDERBIRD_VERSION" ;;
+            beta) version_key="LATEST_THUNDERBIRD_DEVEL_VERSION" ;;
+            *) fail_infra "unsupported Thunderbird channel: ${TB_CHANNEL}" ;;
+          esac
+
+          tb_json="$(curl -fsSL https://product-details.mozilla.org/1.0/thunderbird_versions.json)" \
+            || fail_infra "failed to fetch Thunderbird product details"
+          tb_version="$(printf '%s' "$tb_json" | jq -er --arg key "$version_key" '.[$key] // empty')" \
+            || fail_infra "Thunderbird version key ${version_key} was missing"
+          if [[ ! "$tb_version" =~ ^[0-9]+(\.[0-9]+)*([ab][0-9]+|esr)?$ ]]; then
+            fail_infra "unexpected Thunderbird version format: ${tb_version}"
+          fi
+
+          install_dir="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}"
+          archive="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}.tar.xz"
+          download_url="https://download.mozilla.org/?product=thunderbird-${tb_version}-SSL&os=linux64&lang=en-US"
+          archive_url="https://archive.mozilla.org/pub/thunderbird/releases/${tb_version}/linux-x86_64/en-US/thunderbird-${tb_version}.tar.xz"
+
+          echo "Downloading Thunderbird ${TB_CHANNEL} ${tb_version}"
+          if ! curl -fL "$download_url" -o "$archive"; then
+            echo "::warning::download.mozilla.org failed; trying archive.mozilla.org"
+            curl -fL "$archive_url" -o "$archive" \
+              || fail_infra "failed to download Thunderbird ${TB_CHANNEL} ${tb_version}"
+          fi
+
+          rm -rf "$install_dir"
+          mkdir -p "$install_dir" || fail_infra "failed to create Thunderbird install directory"
+          tar -xf "$archive" -C "$install_dir" --strip-components=1 \
+            || fail_infra "failed to unpack Thunderbird ${TB_CHANNEL} ${tb_version}"
+
+          tb_bin="${install_dir}/thunderbird"
+          [ -x "$tb_bin" ] || fail_infra "Thunderbird binary was not executable"
+          installed_version="$("$tb_bin" --version 2>/dev/null | grep -Eo '[0-9]+(\.[0-9]+)*([ab][0-9]+|esr)?' | head -n 1 || true)"
+          if [ -n "$installed_version" ]; then
+            tb_version="$installed_version"
+          fi
+          echo "Thunderbird ${TB_CHANNEL}: ${tb_version}"
+
+          profile_dir="$(mktemp -d)" || fail_infra "failed to create test profile"
+          mkdir -p "$profile_dir/extensions" || fail_infra "failed to create extension profile directory"
+          cp dist/thunderbird-mcp.xpi "$profile_dir/extensions/thunderbird-mcp@tkasperczyk.dev.xpi" \
+            || fail_infra "failed to install XPI into test profile"
+          cat > "$profile_dir/user.js" <<'PREFS'
+          user_pref("extensions.experiments.enabled", true);
+          user_pref("extensions.autoDisableScopes", 0);
+          user_pref("extensions.enabledScopes", 15);
+          user_pref("extensions.update.enabled", false);
+          user_pref("app.update.enabled", false);
+          user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+          user_pref("datareporting.policy.dataSubmissionEnabled", false);
+          PREFS
+
+          ext_json="${profile_dir}/extensions.json"
+
+          read_addon_state() {
+            EXT_JSON="$ext_json" node <<'NODE'
+          const fs = require('fs');
+          const addonId = 'thunderbird-mcp@tkasperczyk.dev';
+
+          function done(result) {
+            process.stdout.write(JSON.stringify(result));
+          }
+
+          if (!fs.existsSync(process.env.EXT_JSON)) {
+            done({ ok: false, kind: 'missing', message: 'extensions.json is not present yet' });
+            process.exit(0);
+          }
+
+          try {
+            const data = JSON.parse(fs.readFileSync(process.env.EXT_JSON, 'utf8'));
+            if (!Array.isArray(data.addons)) {
+              done({ ok: false, kind: 'unparseable', message: 'extensions.json has no addons array' });
+              process.exit(0);
+            }
+
+            const addon = data.addons.find((item) => item.id === addonId);
+            if (!addon) {
+              done({ ok: false, kind: 'absent', message: 'Extension not found in extensions.json' });
+              process.exit(0);
+            }
+
+            const summary = {
+              id: addon.id,
+              version: addon.version,
+              active: addon.active,
+              appDisabled: addon.appDisabled,
+              userDisabled: addon.userDisabled,
+              signedState: addon.signedState,
+            };
+            const ok = addon.active === true && addon.appDisabled === false;
+
+            done({
+              ok,
+              kind: ok ? null : 'load',
+              message: ok
+                ? 'Extension loaded'
+                : `Extension did not load (appDisabled=${addon.appDisabled}, active=${addon.active})`,
+              addon: summary,
+            });
+          } catch (error) {
+            done({ ok: false, kind: 'unparseable', message: `Failed to inspect extensions.json: ${error.message}` });
+          }
+          NODE
+          }
+
+          set_addon_fields() {
+            local state_json="$1"
+            ext_active="$(printf '%s' "$state_json" | jq -r 'if .addon.active == null then "" else (.addon.active | tostring) end')" \
+              || fail_infra "failed to read active state"
+            ext_app_disabled="$(printf '%s' "$state_json" | jq -r 'if .addon.appDisabled == null then "" else (.addon.appDisabled | tostring) end')" \
+              || fail_infra "failed to read appDisabled state"
+          }
+
+          stop_thunderbird() {
+            if kill -0 "$tb_pid" 2>/dev/null; then
+              kill "$tb_pid" 2>/dev/null || true
+            fi
+            wait "$tb_pid" 2>/dev/null || true
+          }
+
+          MOZ_HEADLESS=1 timeout --kill-after=5s 75s xvfb-run --auto-servernum "$tb_bin" \
+            --profile "$profile_dir" --headless --no-remote > "$tb_log" 2>&1 &
+          tb_pid=$!
+
+          poll_deadline=$((SECONDS + 60))
+          poll_interval=2
+          while [ "$SECONDS" -lt "$poll_deadline" ]; do
+            state_json="$(read_addon_state)" \
+              || state_json='{"ok":false,"kind":"unparseable","message":"state reader failed"}'
+            state_ok="$(printf '%s' "$state_json" | jq -r '.ok // false')" || state_ok="false"
+            if [ "$state_ok" = "true" ]; then
+              set_addon_fields "$state_json"
+              stop_thunderbird
+              echo "Extension loaded OK on Thunderbird ${TB_CHANNEL} ${tb_version}"
+              finish
+            fi
+            if ! kill -0 "$tb_pid" 2>/dev/null; then
+              break
+            fi
+            sleep "$poll_interval"
+          done
+
+          final_state_json="$(read_addon_state)" \
+            || final_state_json='{"ok":false,"kind":"unparseable","message":"state reader failed"}'
+          final_kind="$(printf '%s' "$final_state_json" | jq -r '.kind // ""')" \
+            || fail_infra "extension verification did not return valid JSON"
+          final_message="$(printf '%s' "$final_state_json" | jq -r '.message // "extension verification failed"')" \
+            || fail_infra "extension verification did not return valid JSON"
+          final_ok="$(printf '%s' "$final_state_json" | jq -r '.ok // false')" \
+            || fail_infra "extension verification did not return valid JSON"
+          set_addon_fields "$final_state_json"
+          stop_thunderbird
+
+          if [ "$final_ok" = "true" ]; then
+            echo "Extension loaded OK on Thunderbird ${TB_CHANNEL} ${tb_version}"
+            finish
+          fi
+
+          if [ "$final_kind" = "missing" ]; then
+            echo "::group::Thunderbird log"
+            tail -200 "$tb_log" || true
+            echo "::endgroup::"
+            fail_infra "extensions.json was never created; Thunderbird may not have started"
+          fi
+          if [ "$final_kind" = "unparseable" ]; then
+            fail_infra "$final_message"
+          fi
+
+          fail_load "$final_message"

--- a/.github/workflows/tb-compat-test.yml
+++ b/.github/workflows/tb-compat-test.yml
@@ -15,6 +15,11 @@ jobs:
   compat-test:
     name: TB compat (${{ matrix.channel }})
     runs-on: ubuntu-latest
+    # Beta runs against the next TB major (one ahead of the cap), so it is an
+    # early-warning signal, not a merge gate. Once Thunderbird disables
+    # experiment APIs on a future beta this leg will fail; that must not block
+    # unrelated PRs. The weekly scheduled workflow keeps beta/esr as hard signals.
+    continue-on-error: ${{ matrix.channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tb-version-check.yml
+++ b/.github/workflows/tb-version-check.yml
@@ -1,0 +1,487 @@
+name: Thunderbird Version Compatibility Warning
+
+# Weekly early warning for real Thunderbird load breakage. This intentionally
+# does not bump strict_max_version or open PRs; the manifest cap is broad for
+# self-distributed releases, so beta being ahead of stable is tested as a real
+# load signal rather than as a version-cap failure.
+
+on:
+  schedule:
+    - cron: "23 8 * * 1" # Mondays at 08:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compat-test:
+    name: TB compat (${{ matrix.channel }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, beta, esr]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+
+      - name: Load extension in Thunderbird
+        shell: bash
+        env:
+          # The report job decides whether to fail the workflow and whether to
+          # file an issue. This lets infrastructure failures stay out of issues.
+          EXIT_ON_FAILURE: "false"
+          TB_CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -euo pipefail
+
+          status="success"
+          failure_kind=""
+          message=""
+          tb_version=""
+          ext_active=""
+          ext_app_disabled=""
+          profile_dir=""
+          result_file="${RUNNER_TEMP}/tb-compat-${TB_CHANNEL}.json"
+          tb_log="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}.log"
+
+          write_result() {
+            RESULT_STATUS="$status" \
+            RESULT_FAILURE_KIND="$failure_kind" \
+            RESULT_MESSAGE="$message" \
+            RESULT_TB_CHANNEL="$TB_CHANNEL" \
+            RESULT_TB_VERSION="$tb_version" \
+            RESULT_EXT_ACTIVE="$ext_active" \
+            RESULT_EXT_APP_DISABLED="$ext_app_disabled" \
+            RESULT_PROFILE_DIR="$profile_dir" \
+            RESULT_LOG_FILE="$tb_log" \
+            RESULT_FILE="$result_file" \
+            node <<'NODE'
+          const fs = require('fs');
+
+          function optionalBool(value) {
+            if (value === 'true') return true;
+            if (value === 'false') return false;
+            return null;
+          }
+
+          const result = {
+            channel: process.env.RESULT_TB_CHANNEL,
+            status: process.env.RESULT_STATUS,
+            failureKind: process.env.RESULT_FAILURE_KIND || null,
+            message: process.env.RESULT_MESSAGE || null,
+            thunderbirdVersion: process.env.RESULT_TB_VERSION || null,
+            active: optionalBool(process.env.RESULT_EXT_ACTIVE || ''),
+            appDisabled: optionalBool(process.env.RESULT_EXT_APP_DISABLED || ''),
+            profileDir: process.env.RESULT_PROFILE_DIR || null,
+            logFile: process.env.RESULT_LOG_FILE || null,
+          };
+
+          fs.writeFileSync(process.env.RESULT_FILE, JSON.stringify(result, null, 2) + '\n');
+          NODE
+          }
+
+          finish() {
+            write_result
+            {
+              echo "### Thunderbird compatibility (${TB_CHANNEL})"
+              echo ""
+              echo "- Status: ${status}"
+              if [ -n "$tb_version" ]; then echo "- Thunderbird: ${tb_version}"; fi
+              if [ -n "$ext_app_disabled" ]; then echo "- appDisabled: ${ext_app_disabled}"; fi
+              if [ -n "$ext_active" ]; then echo "- active: ${ext_active}"; fi
+              if [ -n "$message" ]; then echo "- Message: ${message}"; fi
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$status" = "success" ]; then
+              exit 0
+            fi
+            if [ "${EXIT_ON_FAILURE:-true}" = "true" ]; then
+              exit 1
+            fi
+            exit 0
+          }
+
+          fail_infra() {
+            status="infra_failure"
+            failure_kind="infra"
+            message="$1"
+            echo "::error::${message}"
+            finish
+          }
+
+          fail_load() {
+            status="load_failure"
+            failure_kind="load"
+            message="$1"
+            echo "::error::${message}"
+            finish
+          }
+
+          sudo apt-get update -qq || fail_infra "apt-get update failed"
+          sudo apt-get install -y -qq bzip2 curl jq libdbus-glib-1-2 libgtk-3-0 libx11-xcb1 libxt6 xvfb xz-utils zip \
+            || fail_infra "failed to install Thunderbird runtime dependencies"
+          if ! ldconfig -p | grep -q 'libasound.so.2'; then
+            sudo apt-get install -y -qq libasound2t64 \
+              || sudo apt-get install -y -qq libasound2 \
+              || fail_infra "failed to install libasound"
+          fi
+
+          bash scripts/build.sh || fail_infra "scripts/build.sh failed"
+          [ -f dist/thunderbird-mcp.xpi ] || fail_infra "dist/thunderbird-mcp.xpi was not produced"
+
+          case "$TB_CHANNEL" in
+            stable) version_key="LATEST_THUNDERBIRD_VERSION" ;;
+            beta) version_key="LATEST_THUNDERBIRD_DEVEL_VERSION" ;;
+            esr) version_key="THUNDERBIRD_ESR" ;;
+            *) fail_infra "unsupported Thunderbird channel: ${TB_CHANNEL}" ;;
+          esac
+
+          tb_json="$(curl -fsSL https://product-details.mozilla.org/1.0/thunderbird_versions.json)" \
+            || fail_infra "failed to fetch Thunderbird product details"
+          tb_version="$(printf '%s' "$tb_json" | jq -er --arg key "$version_key" '.[$key] // empty')" \
+            || fail_infra "Thunderbird version key ${version_key} was missing"
+          if [[ ! "$tb_version" =~ ^[0-9]+(\.[0-9]+)*([ab][0-9]+|esr)?$ ]]; then
+            fail_infra "unexpected Thunderbird version format: ${tb_version}"
+          fi
+
+          install_dir="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}"
+          archive="${RUNNER_TEMP}/thunderbird-${TB_CHANNEL}.tar.xz"
+          download_url="https://download.mozilla.org/?product=thunderbird-${tb_version}-SSL&os=linux64&lang=en-US"
+          archive_url="https://archive.mozilla.org/pub/thunderbird/releases/${tb_version}/linux-x86_64/en-US/thunderbird-${tb_version}.tar.xz"
+
+          echo "Downloading Thunderbird ${TB_CHANNEL} ${tb_version}"
+          if ! curl -fL "$download_url" -o "$archive"; then
+            echo "::warning::download.mozilla.org failed; trying archive.mozilla.org"
+            curl -fL "$archive_url" -o "$archive" \
+              || fail_infra "failed to download Thunderbird ${TB_CHANNEL} ${tb_version}"
+          fi
+
+          rm -rf "$install_dir"
+          mkdir -p "$install_dir" || fail_infra "failed to create Thunderbird install directory"
+          tar -xf "$archive" -C "$install_dir" --strip-components=1 \
+            || fail_infra "failed to unpack Thunderbird ${TB_CHANNEL} ${tb_version}"
+
+          tb_bin="${install_dir}/thunderbird"
+          [ -x "$tb_bin" ] || fail_infra "Thunderbird binary was not executable"
+          installed_version="$("$tb_bin" --version 2>/dev/null | grep -Eo '[0-9]+(\.[0-9]+)*([ab][0-9]+|esr)?' | head -n 1 || true)"
+          if [ -n "$installed_version" ]; then
+            tb_version="$installed_version"
+          fi
+          echo "Thunderbird ${TB_CHANNEL}: ${tb_version}"
+
+          profile_dir="$(mktemp -d)" || fail_infra "failed to create test profile"
+          mkdir -p "$profile_dir/extensions" || fail_infra "failed to create extension profile directory"
+          cp dist/thunderbird-mcp.xpi "$profile_dir/extensions/thunderbird-mcp@tkasperczyk.dev.xpi" \
+            || fail_infra "failed to install XPI into test profile"
+          cat > "$profile_dir/user.js" <<'PREFS'
+          user_pref("extensions.experiments.enabled", true);
+          user_pref("extensions.autoDisableScopes", 0);
+          user_pref("extensions.enabledScopes", 15);
+          user_pref("extensions.update.enabled", false);
+          user_pref("app.update.enabled", false);
+          user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+          user_pref("datareporting.policy.dataSubmissionEnabled", false);
+          PREFS
+
+          ext_json="${profile_dir}/extensions.json"
+
+          read_addon_state() {
+            EXT_JSON="$ext_json" node <<'NODE'
+          const fs = require('fs');
+          const addonId = 'thunderbird-mcp@tkasperczyk.dev';
+
+          function done(result) {
+            process.stdout.write(JSON.stringify(result));
+          }
+
+          if (!fs.existsSync(process.env.EXT_JSON)) {
+            done({ ok: false, kind: 'missing', message: 'extensions.json is not present yet' });
+            process.exit(0);
+          }
+
+          try {
+            const data = JSON.parse(fs.readFileSync(process.env.EXT_JSON, 'utf8'));
+            if (!Array.isArray(data.addons)) {
+              done({ ok: false, kind: 'unparseable', message: 'extensions.json has no addons array' });
+              process.exit(0);
+            }
+
+            const addon = data.addons.find((item) => item.id === addonId);
+            if (!addon) {
+              done({ ok: false, kind: 'absent', message: 'Extension not found in extensions.json' });
+              process.exit(0);
+            }
+
+            const summary = {
+              id: addon.id,
+              version: addon.version,
+              active: addon.active,
+              appDisabled: addon.appDisabled,
+              userDisabled: addon.userDisabled,
+              signedState: addon.signedState,
+            };
+            const ok = addon.active === true && addon.appDisabled === false;
+
+            done({
+              ok,
+              kind: ok ? null : 'load',
+              message: ok
+                ? 'Extension loaded'
+                : `Extension did not load (appDisabled=${addon.appDisabled}, active=${addon.active})`,
+              addon: summary,
+            });
+          } catch (error) {
+            done({ ok: false, kind: 'unparseable', message: `Failed to inspect extensions.json: ${error.message}` });
+          }
+          NODE
+          }
+
+          set_addon_fields() {
+            local state_json="$1"
+            ext_active="$(printf '%s' "$state_json" | jq -r 'if .addon.active == null then "" else (.addon.active | tostring) end')" \
+              || fail_infra "failed to read active state"
+            ext_app_disabled="$(printf '%s' "$state_json" | jq -r 'if .addon.appDisabled == null then "" else (.addon.appDisabled | tostring) end')" \
+              || fail_infra "failed to read appDisabled state"
+          }
+
+          stop_thunderbird() {
+            if kill -0 "$tb_pid" 2>/dev/null; then
+              kill "$tb_pid" 2>/dev/null || true
+            fi
+            wait "$tb_pid" 2>/dev/null || true
+          }
+
+          MOZ_HEADLESS=1 timeout --kill-after=5s 75s xvfb-run --auto-servernum "$tb_bin" \
+            --profile "$profile_dir" --headless --no-remote > "$tb_log" 2>&1 &
+          tb_pid=$!
+
+          poll_deadline=$((SECONDS + 60))
+          poll_interval=2
+          while [ "$SECONDS" -lt "$poll_deadline" ]; do
+            state_json="$(read_addon_state)" \
+              || state_json='{"ok":false,"kind":"unparseable","message":"state reader failed"}'
+            state_ok="$(printf '%s' "$state_json" | jq -r '.ok // false')" || state_ok="false"
+            if [ "$state_ok" = "true" ]; then
+              set_addon_fields "$state_json"
+              stop_thunderbird
+              echo "Extension loaded OK on Thunderbird ${TB_CHANNEL} ${tb_version}"
+              finish
+            fi
+            if ! kill -0 "$tb_pid" 2>/dev/null; then
+              break
+            fi
+            sleep "$poll_interval"
+          done
+
+          final_state_json="$(read_addon_state)" \
+            || final_state_json='{"ok":false,"kind":"unparseable","message":"state reader failed"}'
+          final_kind="$(printf '%s' "$final_state_json" | jq -r '.kind // ""')" \
+            || fail_infra "extension verification did not return valid JSON"
+          final_message="$(printf '%s' "$final_state_json" | jq -r '.message // "extension verification failed"')" \
+            || fail_infra "extension verification did not return valid JSON"
+          final_ok="$(printf '%s' "$final_state_json" | jq -r '.ok // false')" \
+            || fail_infra "extension verification did not return valid JSON"
+          set_addon_fields "$final_state_json"
+          stop_thunderbird
+
+          if [ "$final_ok" = "true" ]; then
+            echo "Extension loaded OK on Thunderbird ${TB_CHANNEL} ${tb_version}"
+            finish
+          fi
+
+          if [ "$final_kind" = "missing" ]; then
+            echo "::group::Thunderbird log"
+            tail -200 "$tb_log" || true
+            echo "::endgroup::"
+            fail_infra "extensions.json was never created; Thunderbird may not have started"
+          fi
+          if [ "$final_kind" = "unparseable" ]; then
+            fail_infra "$final_message"
+          fi
+
+          fail_load "$final_message"
+
+      - name: Upload compatibility result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tb-compat-${{ matrix.channel }}
+          path: ${{ runner.temp }}/tb-compat-${{ matrix.channel }}.json
+          if-no-files-found: warn
+
+  report:
+    name: Report compatibility failures
+    runs-on: ubuntu-latest
+    needs: compat-test
+    if: ${{ always() }}
+    concurrency:
+      group: thunderbird-version-compat-report
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Download compatibility results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: tb-compat-*
+          path: ${{ runner.temp }}/tb-compat-results
+          merge-multiple: true
+
+      - name: Evaluate compatibility results
+        id: evaluate
+        shell: bash
+        env:
+          ISSUE_BODY_FILE: ${{ runner.temp }}/tb-compat-issue.md
+          RESULTS_DIR: ${{ runner.temp }}/tb-compat-results
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const expectedChannels = ['stable', 'beta', 'esr'];
+          const resultsDir = process.env.RESULTS_DIR;
+          const issueBodyFile = process.env.ISSUE_BODY_FILE;
+          const runUrl = process.env.RUN_URL;
+
+          function readResults() {
+            if (!fs.existsSync(resultsDir)) return [];
+            return fs.readdirSync(resultsDir)
+              .filter((name) => name.endsWith('.json'))
+              .map((name) => {
+                const file = path.join(resultsDir, name);
+                try {
+                  return JSON.parse(fs.readFileSync(file, 'utf8'));
+                } catch (error) {
+                  return {
+                    channel: name.replace(/\.json$/, ''),
+                    status: 'infra_failure',
+                    failureKind: 'infra',
+                    message: `Could not parse result artifact: ${error.message}`,
+                  };
+                }
+              });
+          }
+
+          const results = readResults();
+          const byChannel = new Map(results.map((result) => [result.channel, result]));
+          for (const channel of expectedChannels) {
+            if (!byChannel.has(channel)) {
+              results.push({
+                channel,
+                status: 'infra_failure',
+                failureKind: 'infra',
+                message: 'No compatibility result artifact was uploaded',
+              });
+            }
+          }
+
+          results.sort((a, b) => expectedChannels.indexOf(a.channel) - expectedChannels.indexOf(b.channel));
+          const failures = results.filter((result) => result.status !== 'success');
+          const loadFailures = failures.filter((result) => result.status === 'load_failure');
+          const infraFailures = failures.filter((result) => result.status !== 'load_failure');
+
+          function cell(value) {
+            return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+          }
+
+          const summary = [
+            '### Thunderbird compatibility results',
+            '',
+            '| Channel | Status | Version | appDisabled | active | Message |',
+            '| --- | --- | --- | --- | --- | --- |',
+            ...results.map((result) => [
+              cell(result.channel),
+              cell(result.status),
+              cell(result.thunderbirdVersion),
+              cell(result.appDisabled),
+              cell(result.active),
+              cell(result.message),
+            ].join(' | ').replace(/^/, '| ').replace(/$/, ' |')),
+            '',
+          ].join('\n');
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+          const body = [
+            'Thunderbird compatibility load testing failed in the weekly early-warning workflow.',
+            '',
+            `Run: ${runUrl}`,
+            '',
+            'Load failures:',
+            ...(
+              loadFailures.length > 0
+                ? loadFailures.map((result) => {
+                    const version = result.thunderbirdVersion ? ` ${result.thunderbirdVersion}` : '';
+                    return `- ${result.channel}${version}: ${result.message || 'extension failed to load'} (appDisabled=${result.appDisabled}, active=${result.active})`;
+                  })
+                : ['- None recorded.']
+            ),
+            '',
+            'Other CI/install failures:',
+            ...(
+              infraFailures.length > 0
+                ? infraFailures.map((result) => `- ${result.channel}: ${result.message || result.status}`)
+                : ['- None recorded.']
+            ),
+            '',
+            'No manifest bump was attempted. The workflow only reports real extension load failures.',
+          ].join('\n');
+          fs.writeFileSync(issueBodyFile, body + '\n');
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `any_failed=${failures.length > 0}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `load_failed=${loadFailures.length > 0}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `issue_body_file=${issueBodyFile}\n`);
+          NODE
+
+      - name: Open compatibility issue
+        if: ${{ steps.evaluate.outputs.load_failed == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY_FILE: ${{ steps.evaluate.outputs.issue_body_file }}
+          ISSUE_TITLE: Thunderbird compatibility load test failed
+        with:
+          script: |
+            const fs = require('fs');
+
+            const title = process.env.ISSUE_TITLE;
+            const body = fs.readFileSync(process.env.ISSUE_BODY_FILE, 'utf8');
+            const { owner, repo } = context.repo;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const duplicate = existing.find((issue) => !issue.pull_request && issue.title === title);
+            if (duplicate) {
+              console.log(`Issue #${duplicate.number} already exists, skipping.`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['compatibility', 'bug'],
+              });
+            } catch (error) {
+              if (!/label/i.test(error.message || '')) {
+                throw error;
+              }
+              await github.rest.issues.create({ owner, repo, title, body });
+            }
+
+      - name: Fail scheduled compatibility check
+        if: ${{ steps.evaluate.outputs.any_failed == 'true' }}
+        run: exit 1

--- a/extension/httpd.sys.mjs
+++ b/extension/httpd.sys.mjs
@@ -885,6 +885,7 @@ export var HttpServer = nsHttpServer;
 // addresses (e.g. [::1]), but may also match valid non-canonical IPv6 addresses
 // (e.g. [::127.0.0.1]) and even invalid bracketed addresses ([::], [99999::]).
 
+// BEGIN HOST HEADER IDENTITY HELPERS
 const HOST_REGEX = new RegExp(
   "^(?:" +
     // *( domainlabel "." )
@@ -900,6 +901,53 @@ const HOST_REGEX = new RegExp(
     ")$",
   "i"
 );
+
+function resolveIdentityFromHostHeader(identity, hostPort) {
+  var host, port;
+  var colon = hostPort.lastIndexOf(":");
+  if (hostPort.lastIndexOf("]") > colon) {
+    colon = -1;
+  }
+  if (colon < 0) {
+    host = hostPort;
+    port = "";
+  } else {
+    host = hostPort.substring(0, colon);
+    port = hostPort.substring(colon + 1);
+  }
+
+  // NB: We allow an empty port here because, oddly, a colon may be
+  //     present even without a port number, e.g. "example.com:"; in this
+  //     case the default port applies.
+  if (!HOST_REGEX.test(host) || !/^\d*$/.test(port)) {
+    return { error: HTTP_400, reason: "malformed" };
+  }
+
+  // If we're not given a port, we're stuck, because we don't know what
+  // scheme to use to look up the correct port here, in general.  Since
+  // the HTTPS case requires a tunnel/proxy and thus requires that the
+  // requested URI be absolute (and thus contain the necessary
+  // information), let's assume HTTP will prevail and use that.
+  port = +port || 80;
+
+  var scheme = identity.getScheme(host, port);
+  if (!scheme) {
+    if (identity._host === "0.0.0.0") {
+      // In listenAll/startAll mode the Host header may reflect Docker,
+      // reverse-proxy, or WSL port mapping, so it is NOT a security boundary.
+      // The required Authorization Bearer token is the security boundary.
+      return {
+        scheme: identity.primaryScheme,
+        host: identity.primaryHost,
+        port: identity.primaryPort,
+      };
+    }
+    return { error: HTTP_400, reason: "unrecognized" };
+  }
+
+  return { scheme, host, port };
+}
+// END HOST HEADER IDENTITY HELPERS
 
 /**
  * Represents the identity of a server.  An identity consists of a set of
@@ -1592,54 +1640,30 @@ RequestReader.prototype = {
       // server identity data at this point, because the request just doesn't
       // contain enough data on its own to do this, sadly.
       if (!metadata._host) {
-        var host, port;
         var hostPort = headers.getHeader("Host");
-        var colon = hostPort.lastIndexOf(":");
-        if (hostPort.lastIndexOf("]") > colon) {
-          colon = -1;
-        }
-        if (colon < 0) {
-          host = hostPort;
-          port = "";
-        } else {
-          host = hostPort.substring(0, colon);
-          port = hostPort.substring(colon + 1);
-        }
-
-        // NB: We allow an empty port here because, oddly, a colon may be
-        //     present even without a port number, e.g. "example.com:"; in this
-        //     case the default port applies.
-        if (!HOST_REGEX.test(host) || !/^\d*$/.test(port)) {
+        var resolvedIdentity = resolveIdentityFromHostHeader(identity, hostPort);
+        if (resolvedIdentity.error && resolvedIdentity.reason === "malformed") {
           dumpn(
             "*** malformed hostname (" +
               hostPort +
               ") in Host " +
               "header, 400 time"
           );
-          throw HTTP_400;
+          throw resolvedIdentity.error;
         }
-
-        // If we're not given a port, we're stuck, because we don't know what
-        // scheme to use to look up the correct port here, in general.  Since
-        // the HTTPS case requires a tunnel/proxy and thus requires that the
-        // requested URI be absolute (and thus contain the necessary
-        // information), let's assume HTTP will prevail and use that.
-        port = +port || 80;
-
-        var scheme = identity.getScheme(host, port);
-        if (!scheme) {
+        if (resolvedIdentity.error) {
           dumpn(
             "*** unrecognized hostname (" +
               hostPort +
               ") in Host " +
               "header, 400 time"
           );
-          throw HTTP_400;
+          throw resolvedIdentity.error;
         }
 
-        metadata._scheme = scheme;
-        metadata._host = host;
-        metadata._port = port;
+        metadata._scheme = resolvedIdentity.scheme;
+        metadata._host = resolvedIdentity.host;
+        metadata._port = resolvedIdentity.port;
       }
     } else {
       NS_ASSERT(

--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -22,6 +22,7 @@ const resProto = Cc[
 
 const MCP_DEFAULT_PORT = 8765;
 const MCP_MAX_PORT_ATTEMPTS = 10;
+const CONNECTION_FILE_REFRESH_MS = 30 * 1000;
 
 // Versions of the MCP protocol this server understands. Behavior never depends
 // on the negotiated version inside Thunderbird (the bridge intercepts initialize
@@ -42,6 +43,46 @@ let _cachedExtVersion = null;
 function isListenAllEnabled() {
   try { return Services.prefs.getBoolPref(PREF_LISTEN_ALL, false); } catch { return false; }
 }
+
+function stopConnectionInfoRefreshTimer() {
+  if (globalThis.__tbMcpConnectionInfoRefreshTimer) {
+    try {
+      globalThis.__tbMcpConnectionInfoRefreshTimer.cancel();
+    } catch (e) {
+      console.warn("thunderbird-mcp: failed to stop connection info refresh timer:", e);
+    }
+    globalThis.__tbMcpConnectionInfoRefreshTimer = null;
+  }
+}
+
+// BEGIN CONNECTION INFO REFRESH HELPERS
+function ensureFreshConnectionInfo({
+  port,
+  token,
+  expectedPid,
+  readConnectionInfo,
+  writeConnectionInfo,
+  onCheckError,
+}) {
+  try {
+    const current = readConnectionInfo();
+    const data = current && current.data;
+    if (
+      data &&
+      data.port === port &&
+      data.token === token &&
+      data.pid === expectedPid
+    ) {
+      return current.path;
+    }
+  } catch (e) {
+    if (typeof onCheckError === "function") {
+      onCheckError(e);
+    }
+  }
+  return writeConnectionInfo(port, token);
+}
+// END CONNECTION INFO REFRESH HELPERS
 
 function getExtVersion() {
   if (_cachedExtVersion) return _cachedExtVersion;
@@ -988,6 +1029,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             if (globalThis.__tbMcpServer) {
               try { globalThis.__tbMcpServer.stop(() => {}); } catch { /* ignore */ }
               globalThis.__tbMcpServer = null;
+              stopConnectionInfoRefreshTimer();
             }
             const { HttpServer } = ChromeUtils.importESModule(
               "resource://thunderbird-mcp/httpd.sys.mjs?" + Date.now()
@@ -1178,6 +1220,32 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               } catch {
                 // Best-effort cleanup
               }
+            }
+
+            function ensureConnectionInfo(port, token) {
+              return ensureFreshConnectionInfo({
+                port,
+                token,
+                expectedPid: Services.appinfo.processID,
+                readConnectionInfo,
+                writeConnectionInfo,
+                onCheckError: (e) => {
+                  console.warn("thunderbird-mcp: connection info check failed; rewriting:", e);
+                },
+              });
+            }
+
+            function startConnectionInfoRefresh(port, token) {
+              stopConnectionInfoRefreshTimer();
+              const timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+              timer.initWithCallback(() => {
+                try {
+                  ensureConnectionInfo(port, token);
+                } catch (e) {
+                  console.warn("thunderbird-mcp: failed to refresh connection info:", e);
+                }
+              }, CONNECTION_FILE_REFRESH_MS, Ci.nsITimer.TYPE_REPEATING_SLACK);
+              globalThis.__tbMcpConnectionInfoRefreshTimer = timer;
             }
 
             const authToken = getStableAuthTokenPref() || generateAuthToken();
@@ -6798,11 +6866,17 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             globalThis.__tbMcpServer = server;
             let connFilePath;
             try {
+              // Write the connection file fresh on initial start so the secure
+              // create path (0600 perms, directory checks) always runs. The
+              // refresh timer self-heals it afterward via ensureConnectionInfo
+              // if the OS deletes it while the server keeps running.
               connFilePath = writeConnectionInfo(boundPort, authToken);
+              startConnectionInfoRefresh(boundPort, authToken);
             } catch (writeErr) {
               // Connection file write failed -- stop the orphaned server
               try { server.stop(() => {}); } catch (e) { console.error("thunderbird-mcp: server.stop failed:", e); }
               globalThis.__tbMcpServer = null;
+              stopConnectionInfoRefreshTimer();
               throw writeErr;
             }
             console.log(`Thunderbird MCP server listening on port ${boundPort}`);
@@ -6818,6 +6892,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               try { globalThis.__tbMcpServer.stop(() => {}); } catch (e) { console.error("thunderbird-mcp: server.stop failed:", e); }
               globalThis.__tbMcpServer = null;
             }
+            stopConnectionInfoRefreshTimer();
             // Clear cached promise so a retry can attempt to bind again
             globalThis.__tbMcpStartPromise = null;
             removeConnectionInfo();
@@ -7124,6 +7199,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
           if (globalThis.__tbMcpServer) {
             const stopServer = globalThis.__tbMcpServer;
             globalThis.__tbMcpServer = null;
+            stopConnectionInfoRefreshTimer();
             // Wait for the socket close callback before rebinding the port.
             try {
               await new Promise((resolve) => {
@@ -7157,6 +7233,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
       try { globalThis.__tbMcpServer.stop(() => {}); } catch { /* ignore */ }
       globalThis.__tbMcpServer = null;
     }
+    stopConnectionInfoRefreshTimer();
     // Clear the start promise so a fresh start can occur on reload
     globalThis.__tbMcpStartPromise = null;
 

--- a/test/connection-info-refresh.test.cjs
+++ b/test/connection-info-refresh.test.cjs
@@ -1,0 +1,149 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadConnectionInfoRefreshHelpers() {
+  const apiPath = path.resolve(__dirname, "../extension/mcp_server/api.js");
+  const source = fs.readFileSync(apiPath, "utf8");
+  const startMarker = "// BEGIN CONNECTION INFO REFRESH HELPERS";
+  const endMarker = "// END CONNECTION INFO REFRESH HELPERS";
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  assert.ok(start >= 0, "connection info refresh helper start marker missing");
+  assert.ok(end > start, "connection info refresh helper end marker missing");
+
+  const snippet = source.slice(start, end);
+  const sandbox = {};
+  vm.createContext(sandbox);
+  vm.runInContext(
+    `${snippet}
+this.ensureFreshConnectionInfo = ensureFreshConnectionInfo;`,
+    sandbox
+  );
+  return {
+    ensureFreshConnectionInfo: sandbox.ensureFreshConnectionInfo,
+  };
+}
+
+const { ensureFreshConnectionInfo } = loadConnectionInfoRefreshHelpers();
+
+function makeOptions(overrides) {
+  return {
+    port: 8765,
+    token: "token",
+    expectedPid: 1234,
+    onCheckError() {},
+    ...overrides,
+  };
+}
+
+describe("connection info refresh decision", () => {
+  it("does not rewrite when connection.json already matches the running server", () => {
+    const result = ensureFreshConnectionInfo(makeOptions({
+      readConnectionInfo: () => ({
+        path: "/tmp/thunderbird-mcp/connection.json",
+        data: { port: 8765, token: "token", pid: 1234 },
+      }),
+      writeConnectionInfo() {
+        throw new Error("writeConnectionInfo should not be called");
+      },
+    }));
+
+    assert.equal(result, "/tmp/thunderbird-mcp/connection.json");
+  });
+
+  it("rewrites when connection.json is missing", () => {
+    const writes = [];
+    const result = ensureFreshConnectionInfo(makeOptions({
+      readConnectionInfo: () => ({
+        path: "/tmp/thunderbird-mcp/connection.json",
+        data: null,
+      }),
+      writeConnectionInfo(port, token) {
+        writes.push({ port, token });
+        return "/tmp/thunderbird-mcp/connection.json";
+      },
+    }));
+
+    assert.equal(result, "/tmp/thunderbird-mcp/connection.json");
+    assert.deepEqual(writes, [{ port: 8765, token: "token" }]);
+  });
+
+  for (const staleCase of [
+    {
+      name: "port changed",
+      data: { port: 8766, token: "token", pid: 1234 },
+    },
+    {
+      name: "token changed",
+      data: { port: 8765, token: "old-token", pid: 1234 },
+    },
+    {
+      name: "pid changed",
+      data: { port: 8765, token: "token", pid: 4321 },
+    },
+  ]) {
+    it(`rewrites when connection.json is stale: ${staleCase.name}`, () => {
+      let writeCount = 0;
+      const result = ensureFreshConnectionInfo(makeOptions({
+        readConnectionInfo: () => ({
+          path: "/tmp/thunderbird-mcp/connection.json",
+          data: staleCase.data,
+        }),
+        writeConnectionInfo(port, token) {
+          writeCount++;
+          assert.equal(port, 8765);
+          assert.equal(token, "token");
+          return "/tmp/thunderbird-mcp/connection.json";
+        },
+      }));
+
+      assert.equal(result, "/tmp/thunderbird-mcp/connection.json");
+      assert.equal(writeCount, 1);
+    });
+  }
+
+  it("rewrites when reading or parsing connection.json fails", () => {
+    const errors = [];
+    let writeCount = 0;
+    const parseError = new SyntaxError("Unexpected token");
+
+    const result = ensureFreshConnectionInfo(makeOptions({
+      readConnectionInfo() {
+        throw parseError;
+      },
+      writeConnectionInfo() {
+        writeCount++;
+        return "/tmp/thunderbird-mcp/connection.json";
+      },
+      onCheckError(error) {
+        errors.push(error);
+      },
+    }));
+
+    assert.equal(result, "/tmp/thunderbird-mcp/connection.json");
+    assert.deepEqual(errors, [parseError]);
+    assert.equal(writeCount, 1);
+  });
+
+  it("propagates write failures", () => {
+    const writeError = new Error("disk full");
+
+    assert.throws(
+      () => ensureFreshConnectionInfo(makeOptions({
+        readConnectionInfo: () => ({
+          path: "/tmp/thunderbird-mcp/connection.json",
+          data: null,
+        }),
+        writeConnectionInfo() {
+          throw writeError;
+        },
+      })),
+      (error) => error === writeError
+    );
+  });
+});

--- a/test/httpd-host-fallback.test.cjs
+++ b/test/httpd-host-fallback.test.cjs
@@ -1,0 +1,166 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadHostHeaderIdentityHelpers() {
+  const httpdPath = path.resolve(__dirname, "../extension/httpd.sys.mjs");
+  const source = fs.readFileSync(httpdPath, "utf8");
+  const startMarker = "// BEGIN HOST HEADER IDENTITY HELPERS";
+  const endMarker = "// END HOST HEADER IDENTITY HELPERS";
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  assert.ok(start >= 0, "host header identity helper start marker missing");
+  assert.ok(end > start, "host header identity helper end marker missing");
+
+  const HTTP_400 = { code: 400, description: "Bad Request" };
+  const snippet = source.slice(start, end);
+  const sandbox = { HTTP_400 };
+  vm.createContext(sandbox);
+  vm.runInContext(
+    `${snippet}
+this.resolveIdentityFromHostHeader = resolveIdentityFromHostHeader;`,
+    sandbox
+  );
+  return {
+    HTTP_400,
+    resolveIdentityFromHostHeader: sandbox.resolveIdentityFromHostHeader,
+  };
+}
+
+const { HTTP_400, resolveIdentityFromHostHeader } = loadHostHeaderIdentityHelpers();
+
+function makeIdentity({
+  boundHost = "localhost",
+  primaryScheme = "http",
+  primaryHost = "localhost",
+  primaryPort = 8765,
+  locations = [{ scheme: "http", host: "localhost", port: 8765 }],
+} = {}) {
+  const schemes = new Map();
+  for (const location of locations) {
+    schemes.set(`${location.host}:${location.port}`, location.scheme);
+  }
+  return {
+    _host: boundHost,
+    primaryScheme,
+    primaryHost,
+    primaryPort,
+    getScheme(host, port) {
+      return schemes.get(`${host}:${port}`) || "";
+    },
+  };
+}
+
+function assertBadRequest(result, reason) {
+  assert.equal(result.error, HTTP_400);
+  assert.equal(result.error.code, 400);
+  assert.equal(result.reason, reason);
+}
+
+function assertResolved(result, expected) {
+  assert.equal(result.error, undefined);
+  assert.equal(result.scheme, expected.scheme);
+  assert.equal(result.host, expected.host);
+  assert.equal(result.port, expected.port);
+}
+
+describe("httpd Host header identity resolution", () => {
+  it("keeps a recognized Host identity unchanged", () => {
+    const identity = makeIdentity({
+      locations: [
+        { scheme: "http", host: "localhost", port: 8765 },
+        { scheme: "http", host: "127.0.0.1", port: 8765 },
+      ],
+    });
+
+    assertResolved(resolveIdentityFromHostHeader(identity, "127.0.0.1:8765"), {
+      scheme: "http",
+      host: "127.0.0.1",
+      port: 8765,
+    });
+  });
+
+  it("rejects an unrecognized Host outside listenAll mode", () => {
+    const identity = makeIdentity();
+
+    assertBadRequest(
+      resolveIdentityFromHostHeader(identity, "proxy.example:443"),
+      "unrecognized"
+    );
+  });
+
+  it("falls back to the primary identity for arbitrary listenAll Host names", () => {
+    const identity = makeIdentity({
+      boundHost: "0.0.0.0",
+      primaryHost: "localhost",
+      primaryPort: 8765,
+      locations: [
+        { scheme: "http", host: "localhost", port: 8765 },
+        { scheme: "http", host: "127.0.0.1", port: 8765 },
+      ],
+    });
+
+    assertResolved(resolveIdentityFromHostHeader(identity, "reverse-proxy.example:443"), {
+      scheme: "http",
+      host: "localhost",
+      port: 8765,
+    });
+  });
+
+  it("falls back to the primary identity for port-mapped listenAll requests", () => {
+    const identity = makeIdentity({
+      boundHost: "0.0.0.0",
+      primaryHost: "localhost",
+      primaryPort: 8765,
+    });
+
+    assertResolved(resolveIdentityFromHostHeader(identity, "127.0.0.1:49152"), {
+      scheme: "http",
+      host: "localhost",
+      port: 8765,
+    });
+  });
+
+  it("still rejects malformed Host headers in listenAll mode", () => {
+    const identity = makeIdentity({ boundHost: "0.0.0.0" });
+
+    assertBadRequest(
+      resolveIdentityFromHostHeader(identity, "bad host:8765"),
+      "malformed"
+    );
+    assertBadRequest(
+      resolveIdentityFromHostHeader(identity, "localhost:not-a-port"),
+      "malformed"
+    );
+  });
+
+  it("preserves IPv6 bracket parsing and default-port behavior", () => {
+    const identity = makeIdentity({
+      primaryHost: "[::1]",
+      locations: [
+        { scheme: "http", host: "[::1]", port: 8765 },
+        { scheme: "http", host: "example.com", port: 80 },
+      ],
+    });
+
+    assertResolved(resolveIdentityFromHostHeader(identity, "[::1]:8765"), {
+      scheme: "http",
+      host: "[::1]",
+      port: 8765,
+    });
+    assertResolved(resolveIdentityFromHostHeader(identity, "example.com"), {
+      scheme: "http",
+      host: "example.com",
+      port: 80,
+    });
+    assertResolved(resolveIdentityFromHostHeader(identity, "example.com:"), {
+      scheme: "http",
+      host: "example.com",
+      port: 80,
+    });
+  });
+});


### PR DESCRIPTION
## v0.7.2

Integrates three reviewed fixes. Source only -- no contributor-built binaries; the release XPI is rebuilt at tag time.

### connection.json self-heal (closes #143)
An `nsITimer` re-verifies the connection handoff file against the running server's `{port, token, pid}` every 30s and rewrites it if the OS removes it mid-session (macOS temp cleanup). Startup still writes the file through the secure-create path (0600 perms, directory checks); the timer only self-heals afterward. Integrates #144 -- thanks @JGSphaela. Covered by a real vm-extraction test of the freshness decision.

### Docker listenAll Host-header fallback
When bound to `0.0.0.0` (Docker / reverse-proxy / WSL), an unrecognized Host header now falls back to the primary identity instead of returning 400. Loopback bindings keep strict Host validation and malformed hosts are still rejected. In listenAll mode the Bearer token, not the Host header, is the security boundary. Integrates #154 -- thanks @ticapix. Covered by a real vm-extraction test of host -> identity resolution.

### Thunderbird compatibility CI (supersedes #153)
- **PR smoke test** -- builds the XPI and asserts the extension genuinely loads in headless Thunderbird (`appDisabled:false` AND `active:true`), not just that it isn't appDisabled.
- **Weekly early warning** -- load-tests current stable / beta / ESR (versions fetched dynamically) and opens a deduplicated issue only on real load breakage. No auto-bump -- the manifest cap is broad at `200.*`, so there is nothing to bump.
- `pull_request` (not `pull_request_target`) with `contents:read` only; `issues:write` is scoped to the scheduled report job alone.

Salvages the real-Thunderbird load-test harness from #153 -- thanks @Oaklight -- and drops its auto-bump / auto-PR machinery.

### Verification
- `npm test`: 371 pass / 17 expected skips / 0 fail
- `eslint`: clean (pre-existing warnings only)
- `actionlint` 1.7.12: clean on both workflows (includes shellcheck on the run blocks)

### Notes
- The version bump to `0.7.2` and the committed-XPI rebuild land as the release commits after merge, with the `v0.7.2` tag.
- This PR intentionally exercises the new smoke test on its own changes.
