### PR TITLE
feat: self-hosted auto-update (update_url + updates.json, unsigned, keep gecko.id)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Run tests
         run: node --test test/*.cjs
 
+      - name: Verify gh-pages branch exists
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null; then
+            echo "::error::gh-pages branch does not exist on origin; refusing to create a release without an update-manifest target."
+            exit 1
+          fi
+
       - name: Build extension
         run: bash scripts/build.sh
 
@@ -66,3 +74,73 @@ jobs:
           tag_name: ${{ github.ref_name }}
           fail_on_unmatched_files: true
           files: dist/thunderbird-mcp-${{ github.ref_name }}.xpi
+
+      - name: Publish update manifest to gh-pages
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+
+          XPI="dist/thunderbird-mcp-${GITHUB_REF_NAME}.xpi"
+          TAG="${GITHUB_REF_NAME}"
+          VER="${GITHUB_REF_NAME#v}"
+          HASH="$(sha256sum "$XPI" | cut -d' ' -f1)"
+          ASSET_URL="https://github.com/TKasperczyk/thunderbird-mcp/releases/download/${TAG}/thunderbird-mcp-${TAG}.xpi"
+          TMP_ASSET="$(mktemp)"
+
+          cleanup() {
+            rm -f "$TMP_ASSET"
+            git worktree remove --force /tmp/ghp 2>/dev/null || true
+            git worktree prune || true
+          }
+          trap cleanup EXIT
+
+          downloaded=0
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL "$ASSET_URL" -o "$TMP_ASSET" &&
+              printf '%s  %s\n' "$HASH" "$TMP_ASSET" | sha256sum -c -; then
+              downloaded=1
+              break
+            fi
+            echo "Release asset not ready or hash mismatch on attempt ${attempt}; retrying..."
+            sleep 5
+          done
+
+          if [ "$downloaded" -ne 1 ]; then
+            echo "::error::Release asset ${ASSET_URL} was not downloadable with expected sha256 ${HASH}."
+            exit 1
+          fi
+
+          TAG="$TAG" VER="$VER" HASH="$HASH" node scripts/gen-updates.js > /tmp/updates.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages
+          git worktree remove --force /tmp/ghp 2>/dev/null || true
+          git worktree prune
+          git worktree add /tmp/ghp origin/gh-pages
+          mkdir -p /tmp/ghp/thunderbird-mcp
+          cp /tmp/updates.json /tmp/ghp/thunderbird-mcp/updates.json
+          git -C /tmp/ghp add thunderbird-mcp/updates.json
+
+          if git -C /tmp/ghp diff --cached --quiet; then
+            echo "updates.json unchanged; nothing to publish."
+            exit 0
+          fi
+
+          git -C /tmp/ghp commit -m "Update Thunderbird MCP update manifest for ${TAG}"
+
+          for attempt in 1 2 3; do
+            if git -C /tmp/ghp push origin HEAD:gh-pages; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              break
+            fi
+            echo "Push failed on attempt ${attempt}; rebasing onto latest gh-pages..."
+            git -C /tmp/ghp fetch origin gh-pages:refs/remotes/origin/gh-pages
+            git -C /tmp/ghp rebase origin/gh-pages
+            sleep 3
+          done
+
+          echo "::error::Failed to push thunderbird-mcp/updates.json to gh-pages after retries."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ git clone https://github.com/TKasperczyk/thunderbird-mcp.git
 
 Install `dist/thunderbird-mcp.xpi` in Thunderbird (Tools > Add-ons > Install from File), then restart. A pre-built XPI is included in the repo -- no build step needed.
 
+**Automatic updates:** From v0.7.3 on, the add-on auto-updates through Thunderbird's add-on update check. Thunderbird downloads updates in the background and applies them on the next restart; because this add-on uses an experiment API, updates are not live hot-swapped. v0.7.3 is the last build you need to install by hand because older builds have no `update_url` and cannot auto-discover it. Thunderbird ships with `xpinstall.signatures.required=false`, so unsigned auto-updates work out of the box; a profile hardened to require signatures blocks both manual and automatic installs. If updates do not arrive, check the Add-ons gear menu and make sure **Update Add-ons Automatically** is enabled.
+
 ### 2. Configure your MCP client
 
 Add to your MCP client config (e.g. `~/.claude.json` for Claude Code):
@@ -181,6 +183,7 @@ That's it. Your AI can now access Thunderbird.
 - **Account access control**: Restrict which email accounts are visible to MCP clients via the settings page. Changes take effect immediately.
 - **Tool access control**: Disable specific tools via the settings page. Disabled tools are hidden from `tools/list` and blocked at dispatch.
 - **Localhost only**: By default, the server binds to localhost only. The "Listen on all interfaces" option in settings binds to all IPv4 interfaces for WSL, Docker, or remote access. **This exposes the MCP server to every device on your local network.** Only enable on trusted networks. Auth token is always required.
+- **Auto-update integrity**: Auto-update is a code-delivery channel whose integrity depends on continued control of the GitHub repository, the GitHub Actions token, and the `tomaszkasperczyk.name` registration.
 
 ---
 
@@ -219,7 +222,7 @@ curl -X POST http://127.0.0.1:$PORT \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
-After changing extension code: remove from Thunderbird, restart, reinstall the XPI, restart again. Thunderbird caches aggressively.
+**Dev-only extension reload:** After changing extension source locally, remove the add-on from Thunderbird, restart, reinstall the XPI, and restart again. Thunderbird caches aggressively. Regular users should install v0.7.3 once and let auto-update handle later releases.
 
 ---
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,6 +6,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "thunderbird-mcp@tkasperczyk.dev",
+      "update_url": "https://updates.tomaszkasperczyk.name/thunderbird-mcp/updates.json",
       "strict_min_version": "102.0",
       "strict_max_version": "200.*"
     }

--- a/scripts/gen-updates.js
+++ b/scripts/gen-updates.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_DIR = path.resolve(__dirname, '..');
+const MANIFEST_FILE = path.join(PROJECT_DIR, 'extension', 'manifest.json');
+const ADDON_ID = 'thunderbird-mcp@tkasperczyk.dev';
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    fail(`${name} is required`);
+  }
+  return value;
+}
+
+function readGeckoSettings() {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, 'utf8'));
+  const gecko = manifest.browser_specific_settings?.gecko;
+  if (!gecko) {
+    throw new Error('extension/manifest.json is missing browser_specific_settings.gecko');
+  }
+  if (typeof gecko.strict_min_version !== 'string' || !gecko.strict_min_version) {
+    throw new Error('extension/manifest.json is missing gecko.strict_min_version');
+  }
+  if (typeof gecko.strict_max_version !== 'string' || !gecko.strict_max_version) {
+    throw new Error('extension/manifest.json is missing gecko.strict_max_version');
+  }
+  return gecko;
+}
+
+function main() {
+  const tag = requireEnv('TAG');
+  const ver = requireEnv('VER');
+  const hash = requireEnv('HASH');
+
+  if (ver.startsWith('v')) {
+    fail('VER must not start with "v"');
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(ver)) {
+    fail('VER must match X.Y.Z, for example 0.7.3');
+  }
+  if (tag !== `v${ver}`) {
+    fail(`TAG must equal "v" + VER; expected v${ver}, got ${tag}`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(hash)) {
+    fail('HASH must be a bare lowercase 64-character sha256 hex digest');
+  }
+
+  const gecko = readGeckoSettings();
+  const updateLink = `https://github.com/TKasperczyk/thunderbird-mcp/releases/download/${tag}/thunderbird-mcp-${tag}.xpi`;
+  const updateHash = `sha256:${hash}`;
+
+  if (!/^sha256:[0-9a-f]{64}$/.test(updateHash)) {
+    fail('update_hash must match sha256:<64 lowercase hex characters>');
+  }
+  if (!updateLink.includes(`/${tag}/`)) {
+    fail('update_link must contain the release tag path segment');
+  }
+
+  const updates = {
+    addons: {
+      [ADDON_ID]: {
+        updates: [
+          {
+            version: ver,
+            update_link: updateLink,
+            update_hash: updateHash,
+            applications: {
+              gecko: {
+                strict_min_version: gecko.strict_min_version,
+                strict_max_version: gecko.strict_max_version,
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  process.stdout.write(JSON.stringify(updates, null, 2) + '\n');
+}
+
+try {
+  main();
+} catch (err) {
+  fail(err.message);
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -338,6 +338,7 @@ echo "Installing to profile: $PROFILE_DIR"
 mkdir -p "$EXTENSIONS_DIR"
 
 # Copy extension
+echo "Warning: Re-running install.sh overwrites the AddonManager-managed file and can downgrade an auto-updated build; to bootstrap once, use Tools > Add-ons > Install from File, then let auto-update handle the rest."
 cp "$XPI_FILE" "$EXTENSIONS_DIR/thunderbird-mcp@tkasperczyk.dev.xpi"
 
 echo "Installed! Restart Thunderbird to activate."


### PR DESCRIPTION
## Self-hosted auto-update

Makes the unlisted XPI auto-update via a self-hosted Gecko update manifest -- no AMO/ATN, no signing, and the existing `gecko.id` is untouched (the #111 one-way door is avoided).

The hosting is already live and verified: `https://updates.tomaszkasperczyk.name/thunderbird-mcp/updates.json` (GitHub Pages on the `gh-pages` branch, HTTPS-enforced, Let's Encrypt cert).

### Changes
- **`extension/manifest.json`** -- one `update_url` key added to the gecko block (id / strict_min / strict_max / version unchanged).
- **`scripts/gen-updates.js`** (new) -- zero-dep generator for `updates.json` from `TAG`/`VER`/`HASH` + the manifest's gecko gate. Guards reject a malformed hash, a leading-`v` version, a `VER` that isn't `X.Y.Z`, and a `TAG` that isn't `v$VER` -- because a malformed entry makes Gecko silently ignore the update.
- **`.github/workflows/build-and-release.yml`** -- a preflight (abort the release early if `gh-pages` is missing) and a post-release publish step that hashes the built XPI, re-downloads the uploaded release asset and verifies its sha256 before publishing (fails loud, never points the manifest at a missing/mismatched asset), then writes `thunderbird-mcp/updates.json` to `gh-pages` via a worktree -- preserving the branch's `CNAME` and `index.html`. Both new steps are tag-ref gated.
- **`scripts/install.sh`** -- warns that re-running it overwrites the AddonManager-managed file and can downgrade an auto-updated build.
- **`README.md`** -- documents the one-time v0.7.3 bootstrap, the applies-on-restart behavior, the unsigned (`xpinstall.signatures.required=false`) caveat, the dev-only reload reframe, and the auto-update integrity posture.

### Why unsigned is fine
Thunderbird ships `xpinstall.signatures.required=false` on every channel (Bugzilla 1549562, WONTFIX) and routes manual install and auto-update through the same Gecko `AddonInstall` pipeline -- there is no stricter signature gate on the update path. Signing is also infeasible (no TB signing server; AMO won't sign an experiment add-on).

### Migration (one-time)
`update_url` is read from the *installed* manifest, so builds before v0.7.3 can't auto-discover it. **v0.7.3 is the last build anyone installs by hand**; v0.7.4+ auto-update. Updates apply on the next Thunderbird restart (experiment API, no hot-swap).

### Notes
- No version bump here -- the `0.7.3` bump + XPI rebuild + tag are release commits handled after merge (matching the established release pattern). version-sync stays green.
- The CI publish step only runs on a real tag push, so this PR's CI cannot exercise it; it was reviewed by inspection (actionlint clean, shellcheck via actionlint clean).

### Merge gate
The one must-verify-first item: confirm on a live current Thunderbird that an unsigned XPI installs via the auto-update path (architecture says yes; not yet reproduced). Do not tag v0.7.3 until that passes.

### Verification
- `npm test`: 371 pass / 17 expected skips / 0 fail
- `eslint`: clean (pre-existing warnings only)
- `actionlint` 1.7.x: clean on the workflow (includes shellcheck on the run blocks)
- `gen-updates.js`: good input produces a correct manifest; all guards reject bad input
