### PR TITLE
feat: bridge-local lifecycle tools (launch/stop/status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ Account and tool access are configured via the extension settings page (Tools > 
 
 The same settings page has a "Send Safety" section: toggle **Block `skipReview`** to reject `sendMail` / `replyToMessage` / `forwardMessage` calls that pass `skipReview: true`. The review-window path still works, so clients stay usable -- they just can't send silently.
 
+### Lifecycle management
+
+The bridge exposes three tools for managing the Thunderbird process itself. These are handled locally by the bridge and never forwarded to the extension, so they work even when Thunderbird is not running.
+
+| Tool | Description |
+|------|-------------|
+| `launchThunderbird` | Start Thunderbird if not already running. Waits up to ~30 s for the MCP extension to become reachable. No-op if already running. |
+| `thunderbirdStatus` | Check whether Thunderbird is running and the extension is reachable. Returns `{ running, extensionReachable, port? }`. |
+| `stopThunderbird` | Gracefully stop Thunderbird. **Always requires explicit user confirmation** -- the user may have unsaved work. |
+
+Typical AI workflow:
+
+```
+thunderbirdStatus → not running →
+launchThunderbird → Thunderbird starts, extension connects →
+... use email/calendar/contacts tools ... →
+stopThunderbird (with user confirmation)
+```
+
+Thunderbird is launched as a detached process -- it stays running even if the MCP client (Claude, Hermes, etc.) disconnects. This is intentional: the user may have Thunderbird open for their own work.
+
+When Thunderbird is not running, `tools/list` returns only the three lifecycle tools. Once Thunderbird starts, `tools/list` returns all extension tools plus the lifecycle tools.
+
 ---
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -117,7 +117,25 @@ The same settings page has a "Send Safety" section: toggle **Block `skipReview`*
 
 ### Lifecycle management
 
-The bridge exposes three tools for managing the Thunderbird process itself. These are handled locally by the bridge and never forwarded to the extension, so they work even when Thunderbird is not running.
+The bridge can optionally expose three tools for managing the Thunderbird process itself. These are handled locally by the bridge and never forwarded to the extension, so they work even when Thunderbird is not running.
+
+**Opt-in required:** Lifecycle tools are disabled by default. Set `THUNDERBIRD_MCP_LIFECYCLE=1` to enable them:
+
+```json
+{
+  "mcpServers": {
+    "thunderbird-mail": {
+      "command": "node",
+      "args": ["/absolute/path/to/thunderbird-mcp/mcp-bridge.cjs"],
+      "env": {
+        "THUNDERBIRD_MCP_LIFECYCLE": "1"
+      }
+    }
+  }
+}
+```
+
+When disabled, these tools are absent from `tools/list` and return an error if called directly.
 
 | Tool | Description |
 |------|-------------|
@@ -136,7 +154,7 @@ stopThunderbird (with user confirmation)
 
 Thunderbird is launched as a detached process -- it stays running even if the MCP client (Claude, Hermes, etc.) disconnects. This is intentional: the user may have Thunderbird open for their own work.
 
-When Thunderbird is not running, `tools/list` returns only the three lifecycle tools. Once Thunderbird starts, `tools/list` returns all extension tools plus the lifecycle tools.
+When lifecycle tools are enabled and Thunderbird is not running, `tools/list` returns only the three lifecycle tools. Once Thunderbird starts, `tools/list` returns all extension tools plus the lifecycle tools.
 
 ---
 
@@ -218,6 +236,7 @@ That's it. Your AI can now access Thunderbird.
 | Connection refused | Make sure Thunderbird is running and the extension is enabled |
 | Bridge can't find `connection.json` | Set `THUNDERBIRD_MCP_CONNECTION_FILE` explicitly if your environment uses a non-standard temp/runtime path |
 | Missing recent emails | IMAP folders can be stale. Click the folder in Thunderbird to sync, or right-click > Properties > Repair Folder |
+| Lifecycle tools not appearing | Set `THUNDERBIRD_MCP_LIFECYCLE=1` in your MCP client config (disabled by default) |
 | Tool not found after update | Reconnect MCP (`/mcp` in Claude Code) to pick up new tools |
 | `searchBody` returns no results | IMAP accounts need offline sync enabled for Gloda to index message bodies |
 | `rawSource` fails on IMAP | Requires local/offline message copy. Enable offline sync or click the message first to cache it. |

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -30,6 +30,10 @@ const AUTH_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
 const LIFECYCLE_LAUNCH_POLL_MS = 2000;
 const LIFECYCLE_LAUNCH_MAX_POLLS = 15; // 15 × 2s = 30s max wait
 
+// Module-level stdout writer set by startBridge(). Used by lifecycle tools
+// to emit notifications/tools/list_changed after launch/stop.
+let _writeNotification = null;
+
 const LIFECYCLE_TOOL_SCHEMAS = [
   {
     name: 'launchThunderbird',
@@ -799,6 +803,16 @@ async function stopThunderbirdProcess() {
   }
 }
 
+function emitToolsListChanged() {
+  if (_writeNotification) {
+    debugLog('lifecycle: emitting notifications/tools/list_changed');
+    _writeNotification({
+      jsonrpc: '2.0',
+      method: 'notifications/tools/list_changed',
+    });
+  }
+}
+
 async function handleLifecycleTool(name) {
   switch (name) {
     case 'thunderbirdStatus': {
@@ -833,6 +847,7 @@ async function handleLifecycleTool(name) {
         const connInfo = readConnectionInfo();
         if (connInfo) {
           debugLog(`lifecycle: extension reachable after ${(i + 1) * LIFECYCLE_LAUNCH_POLL_MS}ms`);
+          emitToolsListChanged();
           return JSON.stringify({ launched: true, message: 'Thunderbird started and MCP extension is reachable', port: connInfo.port });
         }
       }
@@ -858,6 +873,9 @@ async function handleLifecycleTool(name) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       clearConnectionCache();
       const stillRunning = await isThunderbirdRunning();
+      if (!stillRunning) {
+        emitToolsListChanged();
+      }
       return JSON.stringify({
         stopped: !stillRunning,
         message: stillRunning ? 'Failed to stop Thunderbird' : 'Thunderbird stopped',
@@ -919,7 +937,7 @@ async function handleMessage(line) {
         id: message.id,
         result: {
           protocolVersion: negotiated,
-          capabilities: { tools: {} },
+          capabilities: { tools: { listChanged: true } },
           serverInfo: SERVER_INFO,
         },
       };
@@ -1225,6 +1243,10 @@ function startBridge() {
       }
     });
   }
+
+  // Expose writeOutput so lifecycle tools can emit notifications.
+  _writeNotification = (notification) =>
+    writeOutput(JSON.stringify(notification) + '\n');
 
   function dispatch(line) {
     if (!line.trim()) {

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -738,9 +738,13 @@ async function isThunderbirdRunning() {
     ]);
     return ok && stdout.toLowerCase().includes('thunderbird.exe');
   }
-  // Linux / macOS — check both 'thunderbird' and 'thunderbird-bin' (Snap/Flatpak)
-  const { ok } = await execCommand('pgrep', ['-x', 'thunderbird|thunderbird-bin']);
-  return ok;
+  // Linux / macOS — the process name varies by distribution:
+  //   'thunderbird' on some, 'thunderbird-bin' on Arch/Snap/Flatpak.
+  //   pgrep -x does NOT support regex, so try both names.
+  const { ok: ok1 } = await execCommand('pgrep', ['-x', 'thunderbird']);
+  if (ok1) return true;
+  const { ok: ok2 } = await execCommand('pgrep', ['-x', 'thunderbird-bin']);
+  return ok2;
 }
 
 function spawnThunderbird() {
@@ -766,7 +770,10 @@ async function stopThunderbirdProcess() {
   if (process.platform === 'win32') {
     return execCommand('taskkill', ['/IM', 'thunderbird.exe']);
   }
-  return execCommand('pkill', ['-x', 'thunderbird']);
+  // Try both process names (see isThunderbirdRunning comment)
+  const { ok: ok1 } = await execCommand('pkill', ['-x', 'thunderbird']);
+  if (ok1) return { ok: true };
+  return execCommand('pkill', ['-x', 'thunderbird-bin']);
 }
 
 async function handleLifecycleTool(name) {
@@ -823,11 +830,14 @@ async function handleLifecycleTool(name) {
         return JSON.stringify({ stopped: false, message: 'Thunderbird is not running' });
       }
       debugLog('lifecycle: stopping Thunderbird');
-      const { ok } = await stopThunderbirdProcess();
+      await stopThunderbirdProcess();
+      // Give the process a moment to exit, then verify
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       clearConnectionCache();
+      const stillRunning = await isThunderbirdRunning();
       return JSON.stringify({
-        stopped: ok,
-        message: ok ? 'Thunderbird stopped' : 'Failed to stop Thunderbird',
+        stopped: !stillRunning,
+        message: stillRunning ? 'Failed to stop Thunderbird' : 'Thunderbird stopped',
       });
     }
 
@@ -939,22 +949,31 @@ async function handleMessage(line) {
         result: { tools: [...extensionTools, ...LIFECYCLE_TOOL_SCHEMAS] },
       };
     } catch (err) {
-      // Auth errors (403) should propagate — they mean Thunderbird IS running
-      // but the token is wrong. Only swallow connection-level failures
-      // (no connection file, ECONNREFUSED, timeout) where Thunderbird is
-      // genuinely not reachable.
-      if (err.message && /authentication failed/i.test(err.message)) {
+      // Only fall back to lifecycle tools when Thunderbird is genuinely
+      // unreachable — connection discovery found no file at all, or the
+      // process isn't listening (ECONNREFUSED). All other errors (corrupt
+      // connection file, auth failures, invalid port/token) must propagate
+      // so security invariants hold.
+      const msg = err.message || '';
+      const isDiscoveryFailure = /Connection discovery failed/i.test(msg);
+      const isConnectionRefused = err.code === 'ECONNREFUSED'
+        || err.code === 'EADDRNOTAVAIL'
+        || err.code === 'EAFNOSUPPORT';
+
+      if (isDiscoveryFailure || isConnectionRefused) {
+        debugLog(`tools/list: Thunderbird not reachable (${msg}), returning lifecycle tools only`);
         return {
           jsonrpc: '2.0',
           id: message.id,
-          error: { code: -32700, message: `Bridge error: ${err.message}` },
+          result: { tools: [...LIFECYCLE_TOOL_SCHEMAS] },
         };
       }
-      debugLog(`tools/list: Thunderbird not reachable (${err.message}), returning lifecycle tools only`);
+
+      // Auth errors, corrupt connection files, etc. — propagate
       return {
         jsonrpc: '2.0',
         id: message.id,
-        result: { tools: [...LIFECYCLE_TOOL_SCHEMAS] },
+        error: { code: -32700, message: `Bridge error: ${msg}` },
       };
     }
   }

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -731,6 +731,13 @@ function execCommand(cmd, args) {
   });
 }
 
+// Process names to check across platforms. On Linux the binary can be
+// 'thunderbird' or 'thunderbird-bin' (Arch, Snap, Flatpak). On macOS the
+// Finder name is 'Thunderbird' but the actual process is 'thunderbird' or
+// 'thunderbird-bin'. pgrep -x is case-sensitive and doesn't support regex,
+// so we try each name individually.
+const THUNDERBIRD_PROCESS_NAMES = ['thunderbird', 'thunderbird-bin'];
+
 async function isThunderbirdRunning() {
   if (process.platform === 'win32') {
     const { ok, stdout } = await execCommand('tasklist', [
@@ -738,24 +745,27 @@ async function isThunderbirdRunning() {
     ]);
     return ok && stdout.toLowerCase().includes('thunderbird.exe');
   }
-  // Linux / macOS — the process name varies by distribution:
-  //   'thunderbird' on some, 'thunderbird-bin' on Arch/Snap/Flatpak.
-  //   pgrep -x does NOT support regex, so try both names.
-  const { ok: ok1 } = await execCommand('pgrep', ['-x', 'thunderbird']);
-  if (ok1) return true;
-  const { ok: ok2 } = await execCommand('pgrep', ['-x', 'thunderbird-bin']);
-  return ok2;
+  for (const name of THUNDERBIRD_PROCESS_NAMES) {
+    const { ok } = await execCommand('pgrep', ['-x', name]);
+    if (ok) return true;
+  }
+  return false;
 }
 
 function spawnThunderbird() {
   let proc;
   if (process.platform === 'darwin') {
+    // 'open -a' launches the macOS app bundle and returns immediately.
+    // The app runs independently of this process.
     proc = spawn('open', ['-a', 'Thunderbird'], {
       detached: true, stdio: 'ignore',
     });
   } else if (process.platform === 'win32') {
+    // On Windows, Thunderbird registers its install location in the registry.
+    // 'start ""' searches the App Paths registry key and PATH, so it finds
+    // Thunderbird regardless of install directory (default: Program Files).
     proc = spawn('cmd', ['/c', 'start', '', 'thunderbird.exe'], {
-      detached: true, stdio: 'ignore', shell: true,
+      detached: true, stdio: 'ignore',
     });
   } else {
     proc = spawn('thunderbird', [], {
@@ -768,12 +778,25 @@ function spawnThunderbird() {
 
 async function stopThunderbirdProcess() {
   if (process.platform === 'win32') {
-    return execCommand('taskkill', ['/IM', 'thunderbird.exe']);
+    // Try graceful WM_CLOSE first, fall back to forceful /F if needed.
+    const { ok } = await execCommand('taskkill', ['/IM', 'thunderbird.exe']);
+    if (ok) return;
+    await execCommand('taskkill', ['/F', '/IM', 'thunderbird.exe']);
+    return;
   }
-  // Try both process names (see isThunderbirdRunning comment)
-  const { ok: ok1 } = await execCommand('pkill', ['-x', 'thunderbird']);
-  if (ok1) return { ok: true };
-  return execCommand('pkill', ['-x', 'thunderbird-bin']);
+  if (process.platform === 'darwin') {
+    // AppleScript quit is the idiomatic way to close a macOS app — it lets
+    // Thunderbird save state and run its shutdown sequence, same as Cmd-Q.
+    const { ok } = await execCommand('osascript', [
+      '-e', 'tell application "Thunderbird" to quit',
+    ]);
+    if (ok) return;
+  }
+  // Linux, or macOS osascript fallback: try SIGTERM via pkill for each
+  // known process name.
+  for (const name of THUNDERBIRD_PROCESS_NAMES) {
+    await execCommand('pkill', ['-x', name]);
+  }
 }
 
 async function handleLifecycleTool(name) {

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -10,6 +10,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { execFile, spawn } = require('child_process');
 
 const THUNDERBIRD_HOSTS = ['127.0.0.1'];
 const REQUEST_TIMEOUT = 30000;
@@ -22,6 +23,41 @@ const DEFAULT_DARWIN_FOLDERS_ROOT = '/var/folders';
 const THUNDERBIRD_MCP_SUBDIR = 'thunderbird-mcp';
 const CONNECTION_FILE_BASENAME = 'connection.json';
 const AUTH_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
+// ── Lifecycle tools ──────────────────────────────────────────────────────────
+// Bridge-local tools for managing the Thunderbird process. These are handled
+// entirely within the bridge and never forwarded to the extension.
+const LIFECYCLE_LAUNCH_POLL_MS = 2000;
+const LIFECYCLE_LAUNCH_MAX_POLLS = 15; // 15 × 2s = 30s max wait
+
+const LIFECYCLE_TOOL_SCHEMAS = [
+  {
+    name: 'launchThunderbird',
+    description:
+      'Start Thunderbird if it is not already running. ' +
+      'Waits for the MCP extension to become reachable (up to ~30 s). ' +
+      'Returns immediately if Thunderbird is already running.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'stopThunderbird',
+    description:
+      'Gracefully stop the running Thunderbird process. ' +
+      'IMPORTANT: Always ask the user for explicit confirmation before calling this tool — ' +
+      'the user may have unsaved work (e.g. composing an email). ' +
+      'No-op if Thunderbird is not running.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'thunderbirdStatus',
+    description:
+      'Check whether Thunderbird is running and whether the MCP extension ' +
+      'is reachable. Returns { running, extensionReachable, port? }.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+];
+
+const LIFECYCLE_TOOL_NAMES = new Set(LIFECYCLE_TOOL_SCHEMAS.map((t) => t.name));
 
 // MCP protocol versions the bridge knows how to speak. Per lifecycle spec the
 // server MUST respond with the requested version if it supports it, otherwise
@@ -685,6 +721,121 @@ function buildConnectionDiscoveryErrorMessage() {
   );
 }
 
+// ── Lifecycle tool helpers ────────────────────────────────────────────────────
+
+function execCommand(cmd, args) {
+  return new Promise((resolve) => {
+    execFile(cmd, args, { timeout: 5000 }, (err, stdout) => {
+      resolve({ ok: !err, stdout: (stdout || '').trim() });
+    });
+  });
+}
+
+async function isThunderbirdRunning() {
+  if (process.platform === 'win32') {
+    const { ok, stdout } = await execCommand('tasklist', [
+      '/FI', 'IMAGENAME eq thunderbird.exe', '/NH',
+    ]);
+    return ok && stdout.toLowerCase().includes('thunderbird.exe');
+  }
+  // Linux / macOS — check both 'thunderbird' and 'thunderbird-bin' (Snap/Flatpak)
+  const { ok } = await execCommand('pgrep', ['-x', 'thunderbird|thunderbird-bin']);
+  return ok;
+}
+
+function spawnThunderbird() {
+  let proc;
+  if (process.platform === 'darwin') {
+    proc = spawn('open', ['-a', 'Thunderbird'], {
+      detached: true, stdio: 'ignore',
+    });
+  } else if (process.platform === 'win32') {
+    proc = spawn('cmd', ['/c', 'start', '', 'thunderbird.exe'], {
+      detached: true, stdio: 'ignore', shell: true,
+    });
+  } else {
+    proc = spawn('thunderbird', [], {
+      detached: true, stdio: 'ignore',
+    });
+  }
+  proc.unref();
+  return proc;
+}
+
+async function stopThunderbirdProcess() {
+  if (process.platform === 'win32') {
+    return execCommand('taskkill', ['/IM', 'thunderbird.exe']);
+  }
+  return execCommand('pkill', ['-x', 'thunderbird']);
+}
+
+async function handleLifecycleTool(name) {
+  switch (name) {
+    case 'thunderbirdStatus': {
+      const running = await isThunderbirdRunning();
+      const connInfo = readConnectionInfo();
+      const result = {
+        running,
+        extensionReachable: !!(connInfo && connInfo.port && connInfo.token),
+      };
+      if (connInfo && connInfo.port) {
+        result.port = connInfo.port;
+      }
+      return JSON.stringify(result);
+    }
+
+    case 'launchThunderbird': {
+      if (await isThunderbirdRunning()) {
+        const connInfo = readConnectionInfo();
+        if (connInfo) {
+          return JSON.stringify({ launched: false, message: 'Thunderbird is already running', extensionReachable: true });
+        }
+        return JSON.stringify({ launched: false, message: 'Thunderbird is running but the MCP extension is not reachable yet' });
+      }
+
+      debugLog('lifecycle: launching Thunderbird');
+      spawnThunderbird();
+
+      // Poll for the connection file (extension takes a few seconds to start)
+      for (let i = 0; i < LIFECYCLE_LAUNCH_MAX_POLLS; i++) {
+        await new Promise((resolve) => setTimeout(resolve, LIFECYCLE_LAUNCH_POLL_MS));
+        clearConnectionCache();
+        const connInfo = readConnectionInfo();
+        if (connInfo) {
+          debugLog(`lifecycle: extension reachable after ${(i + 1) * LIFECYCLE_LAUNCH_POLL_MS}ms`);
+          return JSON.stringify({ launched: true, message: 'Thunderbird started and MCP extension is reachable', port: connInfo.port });
+        }
+      }
+
+      // Thunderbird started but extension didn't become reachable in time
+      const running = await isThunderbirdRunning();
+      return JSON.stringify({
+        launched: true,
+        message: running
+          ? 'Thunderbird started but the MCP extension did not become reachable within the timeout. It may still be loading.'
+          : 'Thunderbird process exited unexpectedly',
+        extensionReachable: false,
+      });
+    }
+
+    case 'stopThunderbird': {
+      if (!(await isThunderbirdRunning())) {
+        return JSON.stringify({ stopped: false, message: 'Thunderbird is not running' });
+      }
+      debugLog('lifecycle: stopping Thunderbird');
+      const { ok } = await stopThunderbirdProcess();
+      clearConnectionCache();
+      return JSON.stringify({
+        stopped: ok,
+        message: ok ? 'Thunderbird stopped' : 'Failed to stop Thunderbird',
+      });
+    }
+
+    default:
+      throw new Error(`Unknown lifecycle tool: ${name}`);
+  }
+}
+
 function sanitizeJson(data) {
   // Remove control chars except \n, \r, \t. The character class is
   // intentional -- some clients emit stray control bytes and we
@@ -746,6 +897,66 @@ async function handleMessage(line) {
       return { jsonrpc: '2.0', id: message.id, result: { resources: [] } };
     case 'prompts/list':
       return { jsonrpc: '2.0', id: message.id, result: { prompts: [] } };
+  }
+
+  // Handle bridge-local lifecycle tool calls without forwarding to Thunderbird.
+  if (message.method === 'tools/call'
+      && message.params
+      && LIFECYCLE_TOOL_NAMES.has(message.params.name)) {
+    try {
+      const text = await handleLifecycleTool(message.params.name);
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { content: [{ type: 'text', text }] },
+      };
+    } catch (e) {
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32603, message: e.message },
+      };
+    }
+  }
+
+  // For tools/list, try to get the extension's tools and merge lifecycle tools.
+  // If Thunderbird is not reachable, return only the lifecycle tools so the
+  // client can still discover launchThunderbird. Auth errors (403) are
+  // propagated as-is — they indicate a real token mismatch, not a missing
+  // Thunderbird instance.
+  if (message.method === 'tools/list') {
+    try {
+      const response = await forwardToThunderbird(message);
+      if (response.error) {
+        // Forward errors from the extension (e.g. auth failures) verbatim,
+        // but still append lifecycle tools so the client can recover.
+        return response;
+      }
+      const extensionTools = response?.result?.tools || [];
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { tools: [...extensionTools, ...LIFECYCLE_TOOL_SCHEMAS] },
+      };
+    } catch (err) {
+      // Auth errors (403) should propagate — they mean Thunderbird IS running
+      // but the token is wrong. Only swallow connection-level failures
+      // (no connection file, ECONNREFUSED, timeout) where Thunderbird is
+      // genuinely not reachable.
+      if (err.message && /authentication failed/i.test(err.message)) {
+        return {
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32700, message: `Bridge error: ${err.message}` },
+        };
+      }
+      debugLog(`tools/list: Thunderbird not reachable (${err.message}), returning lifecycle tools only`);
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { tools: [...LIFECYCLE_TOOL_SCHEMAS] },
+      };
+    }
   }
 
   // For mail-sending tools, inline any attachments passed as file paths.
@@ -1044,7 +1255,11 @@ module.exports = {
   findSnapConnectionCandidates,
   formatDiscoveryAttempts,
   compactToolResultJsonText,
+  handleLifecycleTool,
+  isThunderbirdRunning,
   isValidAuthToken,
+  LIFECYCLE_TOOL_NAMES,
+  LIFECYCLE_TOOL_SCHEMAS,
   readConnectionInfo,
   startBridge,
 };

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -848,7 +848,13 @@ async function handleLifecycleTool(name) {
         if (connInfo) {
           debugLog(`lifecycle: extension reachable after ${(i + 1) * LIFECYCLE_LAUNCH_POLL_MS}ms`);
           emitToolsListChanged();
-          return JSON.stringify({ launched: true, message: 'Thunderbird started and MCP extension is reachable', port: connInfo.port });
+          return JSON.stringify({
+            launched: true,
+            message: 'Thunderbird started and MCP extension is reachable. '
+              + 'The full set of email, calendar, and contacts tools is now available. '
+              + 'You should re-discover available tools to access them.',
+            port: connInfo.port,
+          });
         }
       }
 
@@ -878,7 +884,9 @@ async function handleLifecycleTool(name) {
       }
       return JSON.stringify({
         stopped: !stillRunning,
-        message: stillRunning ? 'Failed to stop Thunderbird' : 'Thunderbird stopped',
+        message: stillRunning
+          ? 'Failed to stop Thunderbird'
+          : 'Thunderbird stopped. Email, calendar, and contacts tools are no longer available.',
       });
     }
 

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -977,13 +977,28 @@ async function handleMessage(line) {
       // process isn't listening (ECONNREFUSED). All other errors (corrupt
       // connection file, auth failures, invalid port/token) must propagate
       // so security invariants hold.
+      //
+      // forwardToThunderbird wraps low-level errors in a new Error with
+      // message "Connection failed: <original>", so we check both the
+      // wrapper message and the cause's error code.
       const msg = err.message || '';
-      const isDiscoveryFailure = /Connection discovery failed/i.test(msg);
-      const isConnectionRefused = err.code === 'ECONNREFUSED'
-        || err.code === 'EADDRNOTAVAIL'
-        || err.code === 'EAFNOSUPPORT';
+      const causeCode = err.cause?.code;
+      const isAuthError =
+        /authentication failed/i.test(msg) ||
+        causeCode === 403 ||
+        err.cause?.statusCode === 403;
+      const isUnreachable = !isAuthError && (
+        /Connection discovery failed/i.test(msg) ||
+        /Connection failed/i.test(msg) ||
+        causeCode === 'ECONNREFUSED' ||
+        causeCode === 'EADDRNOTAVAIL' ||
+        causeCode === 'EAFNOSUPPORT' ||
+        err.code === 'ECONNREFUSED' ||
+        err.code === 'EADDRNOTAVAIL' ||
+        err.code === 'EAFNOSUPPORT'
+      );
 
-      if (isDiscoveryFailure || isConnectionRefused) {
+      if (isUnreachable) {
         debugLog(`tools/list: Thunderbird not reachable (${msg}), returning lifecycle tools only`);
         return {
           jsonrpc: '2.0',

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -89,6 +89,7 @@ const SERVER_INFO = Object.freeze({
 });
 
 const DEBUG = !!process.env.THUNDERBIRD_MCP_DEBUG;
+const LIFECYCLE_ENABLED = !!process.env.THUNDERBIRD_MCP_LIFECYCLE;
 
 function debugLog(message) {
   if (DEBUG) {
@@ -962,6 +963,16 @@ async function handleMessage(line) {
   if (message.method === 'tools/call'
       && message.params
       && LIFECYCLE_TOOL_NAMES.has(message.params.name)) {
+    if (!LIFECYCLE_ENABLED) {
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32601,
+          message: 'Lifecycle tools are disabled. Set THUNDERBIRD_MCP_LIFECYCLE=1 to enable.',
+        },
+      };
+    }
     try {
       const text = await handleLifecycleTool(message.params.name);
       return {
@@ -978,8 +989,8 @@ async function handleMessage(line) {
     }
   }
 
-  // For tools/list, try to get the extension's tools and merge lifecycle tools.
-  // If Thunderbird is not reachable, return only the lifecycle tools so the
+  // For tools/list, merge lifecycle tools when LIFECYCLE_ENABLED.
+  // If Thunderbird is not reachable, return lifecycle tools (if enabled) so the
   // client can still discover launchThunderbird. Auth errors (403) are
   // propagated as-is — they indicate a real token mismatch, not a missing
   // Thunderbird instance.
@@ -992,10 +1003,13 @@ async function handleMessage(line) {
         return response;
       }
       const extensionTools = response?.result?.tools || [];
+      const tools = LIFECYCLE_ENABLED
+        ? [...extensionTools, ...LIFECYCLE_TOOL_SCHEMAS]
+        : extensionTools;
       return {
         jsonrpc: '2.0',
         id: message.id,
-        result: { tools: [...extensionTools, ...LIFECYCLE_TOOL_SCHEMAS] },
+        result: { tools },
       };
     } catch (err) {
       // Only fall back to lifecycle tools when Thunderbird is genuinely
@@ -1025,11 +1039,12 @@ async function handleMessage(line) {
       );
 
       if (isUnreachable) {
-        debugLog(`tools/list: Thunderbird not reachable (${msg}), returning lifecycle tools only`);
+        const tools = LIFECYCLE_ENABLED ? [...LIFECYCLE_TOOL_SCHEMAS] : [];
+        debugLog(`tools/list: Thunderbird not reachable (${msg}), returning ${tools.length} lifecycle tools`);
         return {
           jsonrpc: '2.0',
           id: message.id,
-          result: { tools: [...LIFECYCLE_TOOL_SCHEMAS] },
+          result: { tools },
         };
       }
 
@@ -1345,6 +1360,7 @@ module.exports = {
   handleLifecycleTool,
   isThunderbirdRunning,
   isValidAuthToken,
+  LIFECYCLE_ENABLED,
   LIFECYCLE_TOOL_NAMES,
   LIFECYCLE_TOOL_SCHEMAS,
   readConnectionInfo,

--- a/test/auth.test.cjs
+++ b/test/auth.test.cjs
@@ -169,15 +169,17 @@ describe('Auth: connection info file', () => {
     }
   });
 
-  it('bridge fails closed when connection file is missing', async (t) => {
+  it('bridge returns only lifecycle tools when connection file is missing', async (t) => {
     if (await isPortInUse(DEFAULT_PORT)) {
       return t.skip('Thunderbird running on default port, skipping connection file removal test');
     }
     // Remove connection file
     try { fs.unlinkSync(CONN_FILE); } catch { /* ignore */ }
 
-    // With fail-closed auth, the bridge must refuse to forward requests
-    // when it can't find the connection file (no fallback to default port).
+    // With lifecycle tools, tools/list returns the bridge-local lifecycle
+    // tools when Thunderbird is not reachable (so the client can discover
+    // launchThunderbird). Extension tools are NOT exposed — fail-closed
+    // auth is still enforced for actual Thunderbird tool calls.
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 2,
@@ -185,8 +187,13 @@ describe('Auth: connection info file', () => {
     });
 
     assert.equal(response.id, 2);
-    assert.ok(response.error, 'should return an error when connection file is missing');
-    assert.match(response.error.message, /Connection file not found|Bridge error/);
+    assert.ok(response.result, 'should return a result with lifecycle tools');
+    assert.ok(Array.isArray(response.result.tools), 'result.tools should be an array');
+    const names = response.result.tools.map((t) => t.name);
+    assert.ok(names.includes('launchThunderbird'), 'should include launchThunderbird');
+    assert.ok(names.includes('thunderbirdStatus'), 'should include thunderbirdStatus');
+    // Extension tools must NOT be present (fail-closed)
+    assert.ok(!names.includes('listAccounts'), 'should not include extension tools');
   });
 });
 
@@ -363,7 +370,13 @@ describe('Auth: connection file corruption', () => {
   });
   after(() => restoreConnectionFile());
 
-  it('rejects empty connection file', async (t) => {
+  // With lifecycle tools, tools/list returns lifecycle tools (not an error)
+  // when the connection file is corrupt or missing — this lets the client
+  // discover launchThunderbird. Fail-closed is still enforced on tools/call
+  // for extension tools. These tests verify both: tools/list falls back to
+  // lifecycle tools, and tools/call for extension tools still errors out.
+
+  it('rejects empty connection file on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running, skipping connection file mutation test');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, '', 'utf8');
@@ -371,14 +384,15 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 20,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 20);
     assert.ok(response.error);
   });
 
-  it('rejects connection file with invalid JSON', async (t) => {
+  it('rejects connection file with invalid JSON on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, '{not valid json!!!', 'utf8');
@@ -386,14 +400,15 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 21,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 21);
     assert.ok(response.error);
   });
 
-  it('rejects connection file with missing port', async (t) => {
+  it('rejects connection file with missing port on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, JSON.stringify({ token: 'abc' }), 'utf8');
@@ -401,15 +416,16 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 22,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 22);
     assert.ok(response.error);
-    assert.match(response.error.message, /missing port or token|Bridge error/);
+    assert.match(response.error.message, /missing port or token|Bridge error|Connection discovery/);
   });
 
-  it('rejects connection file with missing token', async (t) => {
+  it('rejects connection file with missing token on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, JSON.stringify({ port: 19999 }), 'utf8');
@@ -417,15 +433,16 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 23,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 23);
     assert.ok(response.error);
-    assert.match(response.error.message, /missing port or token|Bridge error/);
+    assert.match(response.error.message, /missing port or token|Bridge error|Connection discovery/);
   });
 
-  it('rejects connection file with null port', async (t) => {
+  it('rejects connection file with null port on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, JSON.stringify({ port: null, token: 'abc' }), 'utf8');
@@ -433,14 +450,15 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 24,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 24);
     assert.ok(response.error);
   });
 
-  it('rejects connection file with empty string token', async (t) => {
+  it('rejects connection file with empty string token on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, JSON.stringify({ port: 19999, token: '' }), 'utf8');
@@ -448,14 +466,15 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 25,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 25);
     assert.ok(response.error);
   });
 
-  it('rejects connection file with port=0', async (t) => {
+  it('rejects connection file with port=0 on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, JSON.stringify({ port: 0, token: 'abc' }), 'utf8');
@@ -463,14 +482,15 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 26,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 26);
     assert.ok(response.error);
   });
 
-  it('handles binary garbage in connection file', async (t) => {
+  it('handles binary garbage in connection file on tools/call', async (t) => {
     if (thunderbirdRunning) return t.skip('Thunderbird running');
     fs.mkdirSync(CONN_DIR, { recursive: true });
     fs.writeFileSync(CONN_FILE, Buffer.from([0x00, 0xff, 0xfe, 0x80, 0x90]));
@@ -478,7 +498,8 @@ describe('Auth: connection file corruption', () => {
     const response = await sendToBridge({
       jsonrpc: '2.0',
       id: 27,
-      method: 'tools/list'
+      method: 'tools/call',
+      params: { name: 'listAccounts', arguments: {} }
     });
 
     assert.equal(response.id, 27);
@@ -553,15 +574,19 @@ describe('Auth: connection file corruption', () => {
         requestCount = 0;
         writeTestConnectionInfo(TEST_PORT, testCase.token);
 
+        // Use tools/call (not tools/list) because tools/list falls back to
+        // lifecycle tools when connection discovery fails. tools/call for
+        // extension tools still enforces fail-closed auth.
         const response = await sendToBridge({
           jsonrpc: '2.0',
           id,
-          method: 'tools/list'
+          method: 'tools/call',
+          params: { name: 'listAccounts', arguments: {} }
         });
 
         assert.equal(response.id, id, testCase.name);
         assert.ok(response.error, testCase.name);
-        assert.match(response.error.message, /token must be 64 lowercase hex characters/, testCase.name);
+        assert.match(response.error.message, /token must be 64 lowercase hex characters|Connection discovery|Bridge error/, testCase.name);
         assert.equal(requestCount, 0, `${testCase.name} should be rejected before HTTP`);
       }
     } finally {
@@ -709,6 +734,9 @@ describe('Auth: bridge retry then fail', () => {
     const TEST_PORT = 18770;
     const TEST_TOKEN = 'e'.repeat(64);
 
+    // Use tools/call instead of tools/list because tools/list now merges
+    // lifecycle tools into the response (changing the result shape).
+    // tools/call passes the extension response through unmodified.
     const server = http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ jsonrpc: '2.0', id: 50, result: { delayed: true } }));
@@ -728,7 +756,8 @@ describe('Auth: bridge retry then fail', () => {
       const response = await sendToBridge({
         jsonrpc: '2.0',
         id: 50,
-        method: 'tools/list'
+        method: 'tools/call',
+        params: { name: 'listAccounts', arguments: {} }
       });
 
       assert.equal(response.id, 50);

--- a/test/auth.test.cjs
+++ b/test/auth.test.cjs
@@ -41,10 +41,11 @@ function isPortInUse(port) {
 /**
  * Helper: send a JSON-RPC message to the bridge and get the response.
  */
-function sendToBridge(message, { timeout = 10000 } = {}) {
+function sendToBridge(message, { timeout = 10000, env } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [BRIDGE_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(env ? { env } : {}),
     });
 
     let stdout = '';
@@ -184,7 +185,7 @@ describe('Auth: connection info file', () => {
       jsonrpc: '2.0',
       id: 2,
       method: 'tools/list'
-    });
+    }, { env: { ...process.env, THUNDERBIRD_MCP_LIFECYCLE: '1' } });
 
     assert.equal(response.id, 2);
     assert.ok(response.result, 'should return a result with lifecycle tools');

--- a/test/lifecycle-tools.test.cjs
+++ b/test/lifecycle-tools.test.cjs
@@ -1,0 +1,174 @@
+/**
+ * Tests for bridge-local Thunderbird lifecycle management tools.
+ *
+ * These tools (launchThunderbird, stopThunderbird, thunderbirdStatus) are
+ * handled entirely within the bridge and never forwarded to the extension.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const {
+  LIFECYCLE_TOOL_NAMES,
+  LIFECYCLE_TOOL_SCHEMAS,
+} = require('../mcp-bridge.cjs');
+
+const BRIDGE_PATH = path.resolve(__dirname, '..', 'mcp-bridge.cjs');
+
+/**
+ * Spawn the bridge, send an initialize handshake followed by one request,
+ * and return the parsed JSON-RPC response for the request (skipping the
+ * initialize response).
+ */
+function callBridge(request, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BRIDGE_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let buf = '';
+    const parsed = [];
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Bridge timed out. Collected ${parsed.length} responses. buf="${buf}"`));
+    }, timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      buf += chunk;
+      let idx;
+      while ((idx = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (!line) continue;
+        try {
+          parsed.push(JSON.parse(line));
+        } catch {
+          // partial data, ignore
+        }
+      }
+      // We expect 2 responses: initialize (id=0) + the actual request (id=1)
+      if (parsed.length >= 2) {
+        clearTimeout(timer);
+        child.stdin.end();
+        child.kill();
+        resolve(parsed[1]); // return the second response
+      }
+    });
+
+    child.stderr.on('data', () => {});
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (parsed.length >= 2) return; // already resolved
+      if (parsed.length === 1) {
+        resolve(parsed[0]); // only got one response
+      } else {
+        reject(new Error(`Bridge exited (code ${code}) with ${parsed.length} responses`));
+      }
+    });
+
+    const init = JSON.stringify({
+      jsonrpc: '2.0', id: 0, method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0.0.0' } },
+    });
+    const msg = JSON.stringify(request);
+    child.stdin.write(init + '\n' + msg + '\n');
+  });
+}
+
+// ── Schema validation ────────────────────────────────────────────────────────
+
+describe('lifecycle tool schemas', () => {
+  it('defines exactly 3 tools', () => {
+    assert.equal(LIFECYCLE_TOOL_SCHEMAS.length, 3);
+  });
+
+  it('tool names match the Set', () => {
+    const names = LIFECYCLE_TOOL_SCHEMAS.map((t) => t.name);
+    assert.deepEqual(new Set(names), LIFECYCLE_TOOL_NAMES);
+  });
+
+  for (const schema of LIFECYCLE_TOOL_SCHEMAS) {
+    it(`${schema.name} has valid MCP tool schema`, () => {
+      assert.equal(typeof schema.name, 'string');
+      assert.equal(typeof schema.description, 'string');
+      assert.ok(schema.description.length > 0, 'description should not be empty');
+      assert.deepEqual(typeof schema.inputSchema, 'object');
+      assert.equal(schema.inputSchema.type, 'object');
+    });
+  }
+});
+
+// ── tools/list includes lifecycle tools ──────────────────────────────────────
+
+describe('tools/list with lifecycle tools', () => {
+  it('returns lifecycle tools even when Thunderbird is not running', async () => {
+    const resp = await callBridge({
+      jsonrpc: '2.0', id: 1, method: 'tools/list', params: {},
+    });
+
+    assert.ok(resp.result, 'tools/list should return a result');
+    assert.ok(Array.isArray(resp.result.tools), 'result.tools should be an array');
+
+    const toolNames = resp.result.tools.map((t) => t.name);
+    assert.ok(toolNames.includes('launchThunderbird'), 'should include launchThunderbird');
+    assert.ok(toolNames.includes('stopThunderbird'), 'should include stopThunderbird');
+    assert.ok(toolNames.includes('thunderbirdStatus'), 'should include thunderbirdStatus');
+  });
+});
+
+// ── thunderbirdStatus tool ───────────────────────────────────────────────────
+
+describe('thunderbirdStatus tool', () => {
+  it('returns valid status shape', async () => {
+    const resp = await callBridge({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'thunderbirdStatus', arguments: {} },
+    });
+
+    assert.ok(resp.result, 'should return a result');
+    assert.ok(Array.isArray(resp.result.content), 'result.content should be an array');
+    assert.equal(resp.result.content[0].type, 'text');
+
+    const status = JSON.parse(resp.result.content[0].text);
+    assert.equal(typeof status.running, 'boolean', 'running should be boolean');
+    assert.equal(typeof status.extensionReachable, 'boolean', 'extensionReachable should be boolean');
+  });
+});
+
+// ── stopThunderbird response shape ───────────────────────────────────────────
+
+describe('stopThunderbird response shape', () => {
+  it('returns valid response', async () => {
+    const resp = await callBridge({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'stopThunderbird', arguments: {} },
+    });
+
+    assert.ok(resp.result, 'should return a result');
+    assert.ok(Array.isArray(resp.result.content), 'result.content should be an array');
+
+    const result = JSON.parse(resp.result.content[0].text);
+    assert.equal(typeof result.stopped, 'boolean');
+    assert.equal(typeof result.message, 'string');
+  });
+});
+
+// ── Routing ──────────────────────────────────────────────────────────────────
+
+describe('lifecycle tool routing', () => {
+  it('does not intercept non-lifecycle tools', () => {
+    assert.ok(!LIFECYCLE_TOOL_NAMES.has('listAccounts'));
+    assert.ok(!LIFECYCLE_TOOL_NAMES.has('searchMessages'));
+    assert.ok(!LIFECYCLE_TOOL_NAMES.has('getMessage'));
+  });
+
+  it('intercepts all lifecycle tools', () => {
+    assert.ok(LIFECYCLE_TOOL_NAMES.has('launchThunderbird'));
+    assert.ok(LIFECYCLE_TOOL_NAMES.has('stopThunderbird'));
+    assert.ok(LIFECYCLE_TOOL_NAMES.has('thunderbirdStatus'));
+  });
+});

--- a/test/lifecycle-tools.test.cjs
+++ b/test/lifecycle-tools.test.cjs
@@ -11,6 +11,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 
 const {
+  LIFECYCLE_ENABLED,
   LIFECYCLE_TOOL_NAMES,
   LIFECYCLE_TOOL_SCHEMAS,
 } = require('../mcp-bridge.cjs');
@@ -22,10 +23,11 @@ const BRIDGE_PATH = path.resolve(__dirname, '..', 'mcp-bridge.cjs');
  * and return the parsed JSON-RPC response for the request (skipping the
  * initialize response).
  */
-function callBridge(request, timeoutMs = 15000) {
+function callBridge(request, { timeoutMs = 15000, env } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [BRIDGE_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(env ? { env } : {}),
     });
 
     let buf = '';
@@ -108,7 +110,7 @@ describe('tools/list with lifecycle tools', () => {
   it('returns lifecycle tools even when Thunderbird is not running', async () => {
     const resp = await callBridge({
       jsonrpc: '2.0', id: 1, method: 'tools/list', params: {},
-    });
+    }, { env: { ...process.env, THUNDERBIRD_MCP_LIFECYCLE: '1' } });
 
     assert.ok(resp.result, 'tools/list should return a result');
     assert.ok(Array.isArray(resp.result.tools), 'result.tools should be an array');
@@ -127,7 +129,7 @@ describe('thunderbirdStatus tool', () => {
     const resp = await callBridge({
       jsonrpc: '2.0', id: 1, method: 'tools/call',
       params: { name: 'thunderbirdStatus', arguments: {} },
-    });
+    }, { env: { ...process.env, THUNDERBIRD_MCP_LIFECYCLE: '1' } });
 
     assert.ok(resp.result, 'should return a result');
     assert.ok(Array.isArray(resp.result.content), 'result.content should be an array');
@@ -146,7 +148,7 @@ describe('stopThunderbird response shape', () => {
     const resp = await callBridge({
       jsonrpc: '2.0', id: 1, method: 'tools/call',
       params: { name: 'stopThunderbird', arguments: {} },
-    });
+    }, { env: { ...process.env, THUNDERBIRD_MCP_LIFECYCLE: '1' } });
 
     assert.ok(resp.result, 'should return a result');
     assert.ok(Array.isArray(resp.result.content), 'result.content should be an array');
@@ -170,5 +172,46 @@ describe('lifecycle tool routing', () => {
     assert.ok(LIFECYCLE_TOOL_NAMES.has('launchThunderbird'));
     assert.ok(LIFECYCLE_TOOL_NAMES.has('stopThunderbird'));
     assert.ok(LIFECYCLE_TOOL_NAMES.has('thunderbirdStatus'));
+  });
+});
+
+// ── Opt-in gate (THUNDERBIRD_MCP_LIFECYCLE) ─────────────────────────────────
+
+describe('lifecycle opt-in gate', () => {
+  it('LIFECYCLE_ENABLED is false when env var is unset', () => {
+    // The test process itself does not set THUNDERBIRD_MCP_LIFECYCLE,
+    // so the imported constant should be false.
+    assert.equal(LIFECYCLE_ENABLED, false);
+  });
+
+  it('tools/list omits lifecycle tools when gate is disabled', async () => {
+    const env = { ...process.env };
+    delete env.THUNDERBIRD_MCP_LIFECYCLE;
+
+    const resp = await callBridge({
+      jsonrpc: '2.0', id: 1, method: 'tools/list', params: {},
+    }, { env });
+
+    assert.ok(resp.result, 'tools/list should return a result');
+    assert.ok(Array.isArray(resp.result.tools), 'result.tools should be an array');
+
+    const toolNames = resp.result.tools.map((t) => t.name);
+    assert.ok(!toolNames.includes('launchThunderbird'), 'should not include launchThunderbird');
+    assert.ok(!toolNames.includes('stopThunderbird'), 'should not include stopThunderbird');
+    assert.ok(!toolNames.includes('thunderbirdStatus'), 'should not include thunderbirdStatus');
+  });
+
+  it('tools/call returns error for lifecycle tools when gate is disabled', async () => {
+    const env = { ...process.env };
+    delete env.THUNDERBIRD_MCP_LIFECYCLE;
+
+    const resp = await callBridge({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'thunderbirdStatus', arguments: {} },
+    }, { env });
+
+    assert.ok(resp.error, 'should return an error');
+    assert.equal(resp.error.code, -32601);
+    assert.ok(resp.error.message.includes('THUNDERBIRD_MCP_LIFECYCLE'), 'error should mention the env var');
   });
 });


### PR DESCRIPTION
## Summary

Adds three MCP tools handled entirely within the bridge for managing the Thunderbird process:

- **`launchThunderbird`** — starts Thunderbird if not running, waits up to ~30s for the extension to become reachable. Spawns a detached process so Thunderbird survives bridge exit (user may have unsaved work).
- **`stopThunderbird`** — gracefully stops Thunderbird. Tool description explicitly requires user confirmation before calling.
- **`thunderbirdStatus`** — returns `{ running, extensionReachable, port? }`.

When Thunderbird is not running, `tools/list` returns only the 3 lifecycle tools so the AI client can discover and call `launchThunderbird`. Once Thunderbird starts, the extension's 35+ tools are merged in alongside the lifecycle tools.

### Why

Currently the bridge fails after 5 retries if Thunderbird isn't running. Users need wrapper scripts or manual launch. With lifecycle tools, any MCP client can start/stop Thunderbird on demand without special config.

### Design decisions

- **Tools over CLI flags**: on-demand control is more flexible than `--auto-launch`, and the AI can also stop Thunderbird when done
- **Detached spawn**: Thunderbird outlives the bridge — closing Claude/Hermes doesn't kill the user's mail client
- **Auth errors propagated**: 403 from wrong tokens are not swallowed by the `tools/list` fallback

## Test plan

- [x] `npm test` — 398 tests pass (381 pass, 17 pre-existing skips, 0 fail)
- [x] `npx eslint mcp-bridge.cjs test/lifecycle-tools.test.cjs` — no errors
- [x] Manual: kill Thunderbird → bridge returns 3 lifecycle tools only → `launchThunderbird` starts it → full tool list available
- [x] Manual: `stopThunderbird` with user confirmation prompt