### PR TITLE
fix(search): keep searchMessages cooperative and bounded (fixes main-thread freezes/timeouts on large folders)

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -134,6 +134,14 @@ const CRUD_ORDER = { read: 0, create: 1, update: 2, delete: 3 };
 const UNDISABLEABLE_TOOLS = new Set(["listAccounts", "listFolders", "getAccountAccess"]);
 const MAX_SEARCH_RESULTS_CAP = 200;
 const SEARCH_COLLECTION_CAP = 10000;
+// searchMessages enumerates message headers on Thunderbird's main thread, so a
+// large folder (or an unscoped, whole-account search) can freeze the UI and blow
+// past the bridge's 30s request timeout. To stay cooperative we yield to the
+// event loop every SEARCH_YIELD_EVERY headers, and abort after SEARCH_TIME_BUDGET_MS
+// (kept safely under the 30s bridge timeout) — returning partial results with a
+// `truncated` flag instead of hanging or timing out.
+const SEARCH_YIELD_EVERY = 2000;
+const SEARCH_TIME_BUDGET_MS = 20000;
 const DEFAULT_GET_MESSAGES_LIMIT = 10;
 // 20 is a reasonable upper bound for now; adjust later if usage supports it.
 const MAX_GET_MESSAGES_LIMIT = 20;
@@ -2789,7 +2797,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               });
             }
 
-	            function searchMessages(query, folderPath, startDate, endDate, maxResults, offset, sortOrder, unreadOnly, flaggedOnly, tag, includeSubfolders, countOnly, searchBody, dedupByMessageId) {
+	            async function searchMessages(query, folderPath, startDate, endDate, maxResults, offset, sortOrder, unreadOnly, flaggedOnly, tag, includeSubfolders, countOnly, searchBody, dedupByMessageId) {
 	              // Gloda full-body search path (async)
 	              if (searchBody) {
 	                if (!GlodaMsgSearcher) return { error: "Gloda full-text index is not available" };
@@ -2836,17 +2844,33 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               );
               const normalizedSortOrder = sortOrder === "asc" ? "asc" : "desc";
 
-              function searchFolder(folder) {
-                if (results.length >= SEARCH_COLLECTION_CAP) return;
+              // Cooperative-scan state (see SEARCH_TIME_BUDGET_MS above).
+              const scanDeadline = Date.now() + SEARCH_TIME_BUDGET_MS;
+              let scannedCount = 0;
+              let timedOut = false;
+
+              async function searchFolder(folder, refresh) {
+                if (results.length >= SEARCH_COLLECTION_CAP || timedOut) return;
 
                 try {
-                  refreshImapFolderSync(folder);
+                  // Only force an IMAP sync for the explicitly-requested folder.
+                  // Refreshing every folder during a recursive or whole-account
+                  // scan triggers an updateFolder storm across the whole tree.
+                  if (refresh) refreshImapFolderSync(folder);
 
                   const db = folder.msgDatabase;
                   if (!db) return;
 
                   for (const msgHdr of db.enumerateMessages()) {
                     if (results.length >= SEARCH_COLLECTION_CAP) break;
+
+                    // Yield to the event loop every SEARCH_YIELD_EVERY headers so
+                    // Thunderbird's UI stays responsive, and abort the scan once
+                    // the time budget is exhausted (marking the result partial).
+                    if ((++scannedCount % SEARCH_YIELD_EVERY) === 0) {
+                      if (Date.now() > scanDeadline) { timedOut = true; break; }
+                      await new Promise(resolve => Services.tm.dispatchToMainThread(resolve));
+                    }
 
                     // Check cheap numeric/boolean filters before string work
                     const msgDateTs = msgHdr.date || 0;
@@ -2908,11 +2932,13 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   // Skip inaccessible folders
                 }
 
+                if (timedOut) return;
+
                 const recurse = includeSubfolders !== false; // default true
                 if (recurse && folder.hasSubFolders) {
                   for (const subfolder of folder.subFolders) {
-                    if (results.length >= SEARCH_COLLECTION_CAP) break;
-                    searchFolder(subfolder);
+                    if (results.length >= SEARCH_COLLECTION_CAP || timedOut) break;
+                    await searchFolder(subfolder, false);
                   }
                 }
               }
@@ -2920,23 +2946,38 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
               if (folderPath) {
                 const result = getAccessibleFolder(folderPath);
                 if (result.error) return result;
-                searchFolder(result.folder);
+                await searchFolder(result.folder, true);
               } else {
                 for (const account of getAccessibleAccounts()) {
-                  if (results.length >= SEARCH_COLLECTION_CAP) break;
-                  searchFolder(account.incomingServer.rootFolder);
+                  if (results.length >= SEARCH_COLLECTION_CAP || timedOut) break;
+                  await searchFolder(account.incomingServer.rootFolder, false);
                 }
               }
+
+              const collectionCapped = results.length >= SEARCH_COLLECTION_CAP;
+              const incomplete = timedOut || collectionCapped;
+              const truncationNote = timedOut
+                ? `Search stopped after ${SEARCH_TIME_BUDGET_MS / 1000}s (${scannedCount} messages scanned); results are partial. Narrow with folderPath, includeSubfolders:false, or a date range.`
+                : `Search hit the ${SEARCH_COLLECTION_CAP}-match collection cap; results are partial. Narrow the search to see the rest.`;
 
               const finalResults = dedupByMessageId !== false ? dedupeSearchMessageResults(results) : results;
 
               if (countOnly) {
-                return { count: finalResults.length };
+                return incomplete
+                  ? { count: finalResults.length, truncated: true, message: truncationNote }
+                  : { count: finalResults.length };
               }
 
               finalResults.sort((a, b) => normalizedSortOrder === "asc" ? a._dateTs - b._dateTs : b._dateTs - a._dateTs);
 
-              return paginate(finalResults, offset, effectiveLimit);
+              const page = paginate(finalResults, offset, effectiveLimit);
+              if (incomplete) {
+                // paginate returns a bare array when no offset was supplied; wrap it
+                // so the truncation signal always rides alongside the results.
+                const wrapped = Array.isArray(page) ? { messages: page } : page;
+                return { ...wrapped, truncated: true, message: truncationNote };
+              }
+              return page;
             }
 
             function searchContacts(query, maxResults) {


### PR DESCRIPTION
## Problem

`searchMessages` (the default, non-`searchBody` path) can freeze the Thunderbird UI and time out — and occasionally crash TB — on large mailstores. In testing against an IMAP account with a ~191k-message INBOX and a ~219k-message All Mail folder, most searches returned `Bridge error: Request to Thunderbird timed out`; scoping to a small folder returned instantly.

## Root cause

The search is a synchronous linear scan on TB's main thread (`extension/mcp_server/api.js`, `searchFolder` → `db.enumerateMessages()`), recursing every subfolder. Cost scales with **folder size, not match count**:

- `maxResults` only trims the *returned* slice — it doesn't bound the scan.
- `startDate`/`endDate` just `continue` past non-matches — they don't prune enumeration.
- The only early exit is `SEARCH_COLLECTION_CAP` (10 000 **matches**), so a rare-term query never trips it and reads every header (MIME-decoding subject/author/recipients each).
- A no-folder search recurses **every account's root folder** = the entire mailstore.
- `refreshImapFolderSync` calls `folder.updateFolder()` on **every** folder it visits, so an unscoped search also fires an `updateFolder` storm across the whole tree.

Because the loop never yields, the UI is frozen the whole time; the bridge gives up at its 30 s `REQUEST_TIMEOUT` while TB keeps churning, and opening a 200k-message `msgDatabase` + building a large result array can tip a long-lived instance into an OOM/hang.

## Fix

Make the scan **cooperative and bounded**, without changing matching semantics:

- **Yield** to the event loop every `SEARCH_YIELD_EVERY` (2000) enumerated headers via `Services.tm.dispatchToMainThread`, so the UI stays responsive.
- **Time budget:** abort after `SEARCH_TIME_BUDGET_MS` (20 s, safely under the 30 s bridge timeout) and return **partial results** flagged `{ truncated: true, message }` instead of hanging or erroring. The same flag is now surfaced when the pre-existing 10 000-match collection cap is hit (previously a silent truncation).
- **Stop the `updateFolder` storm:** only force an IMAP sync on the *explicitly requested* folder, not on every folder of a recursive/whole-account scan.

`searchMessages` becomes `async` (its sole caller already `await`s it).

## Compatibility

- Matching behavior is unchanged.
- Result shape is unchanged for **complete** searches (bare array without `offset`, paginated object with `offset`). Only **incomplete** searches change shape — they return `{ messages, truncated: true, message, ... }` so the partial-result signal always rides with the data.

## Testing

- `node --test test/*.cjs` → **388 tests, 0 failures** (17 skipped, pre-existing).
- `node --check` clean on `api.js` and `mcp-bridge.cjs`.
- ⚠️ Not runtime-tested inside Thunderbird (the API module needs the live TB/Gloda/msgDatabase environment). Please exercise a large-folder and an unscoped search before merging. Marked **draft** for that reason.

## Possible follow-ups (not in this PR)

- Route unscoped/large-folder searches through the **Gloda index** for O(index) instead of O(folder) — deferred because Gloda full-text is token-based and would change substring-match semantics; wanted a behavior-preserving reliability fix first.
- The same blocking `enumerateMessages()` pattern appears in `getRecentMessages` and a few other handlers; they could take the same cooperative treatment.
- Make the budget/yield thresholds configurable via prefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
