### PR TITLE
feat(connection): support remote host entries in connection.json

### DIFF
--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -10,8 +10,9 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const net = require('net');
 
-const THUNDERBIRD_HOSTS = ['127.0.0.1'];
+const DEFAULT_THUNDERBIRD_HOSTS = ['127.0.0.1'];
 const REQUEST_TIMEOUT = 30000;
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_MAX_RETRIES = 5;
@@ -22,6 +23,7 @@ const DEFAULT_DARWIN_FOLDERS_ROOT = '/var/folders';
 const THUNDERBIRD_MCP_SUBDIR = 'thunderbird-mcp';
 const CONNECTION_FILE_BASENAME = 'connection.json';
 const AUTH_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+const HOSTNAME_PATTERN = /^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
 
 // MCP protocol versions the bridge knows how to speak. Per lifecycle spec the
 // server MUST respond with the requested version if it supports it, otherwise
@@ -58,6 +60,38 @@ function debugLog(message) {
 
 function isValidAuthToken(token) {
   return typeof token === 'string' && AUTH_TOKEN_PATTERN.test(token);
+}
+
+function normalizeConnectionHost(host) {
+  if (typeof host !== 'string') {
+    throw new Error('Invalid connection file: host must be a string');
+  }
+
+  const trimmed = host.trim();
+  if (!trimmed) {
+    throw new Error('Invalid connection file: host must not be empty');
+  }
+
+  const normalized = trimmed.startsWith('[') && trimmed.endsWith(']')
+    ? trimmed.slice(1, -1)
+    : trimmed;
+
+  if (net.isIP(normalized)) {
+    return normalized;
+  }
+
+  if (HOSTNAME_PATTERN.test(normalized)) {
+    return normalized;
+  }
+
+  throw new Error('Invalid connection file: host must be a hostname or IP address');
+}
+
+function getConnectionHosts(connInfo) {
+  if (!connInfo || connInfo.host === undefined || connInfo.host === null) {
+    return DEFAULT_THUNDERBIRD_HOSTS;
+  }
+  return [normalizeConnectionHost(connInfo.host)];
 }
 
 let cachedConnectionInfo = null;
@@ -907,8 +941,10 @@ async function forwardToThunderbird(message) {
       throw new Error('Invalid connection file: token must be 64 lowercase hex characters');
     }
 
+    const requestHosts = getConnectionHosts(connInfo);
+
     try {
-      return await tryAllHosts(THUNDERBIRD_HOSTS, postData, connInfo.port, connInfo.token);
+      return await tryAllHosts(requestHosts, postData, connInfo.port, connInfo.token);
     } catch (err) {
       if (!isRetryableConnectionError(err)) {
         throw err;
@@ -1043,8 +1079,10 @@ module.exports = {
   findMacOsConnectionCandidates,
   findSnapConnectionCandidates,
   formatDiscoveryAttempts,
+  getConnectionHosts,
   compactToolResultJsonText,
   isValidAuthToken,
+  normalizeConnectionHost,
   readConnectionInfo,
   startBridge,
 };

--- a/test/auth.test.cjs
+++ b/test/auth.test.cjs
@@ -89,9 +89,9 @@ function sendToBridge(message, { timeout = 10000 } = {}) {
 /**
  * Write a test connection.json file.
  */
-function writeTestConnectionInfo(port, token) {
+function writeTestConnectionInfo(port, token, extraFields = {}) {
   fs.mkdirSync(CONN_DIR, { recursive: true });
-  fs.writeFileSync(CONN_FILE, JSON.stringify({ port, token, pid: process.pid }), 'utf8');
+  fs.writeFileSync(CONN_FILE, JSON.stringify({ port, token, pid: process.pid, ...extraFields }), 'utf8');
 }
 
 /**
@@ -117,7 +117,7 @@ function restoreConnectionFile() {
   }
 }
 
-describe('Auth: connection info file', () => {
+describe('Auth: connection info file', { concurrency: false }, () => {
   before(async () => {
     backupConnectionFile();
   });
@@ -169,6 +169,60 @@ describe('Auth: connection info file', () => {
     }
   });
 
+  it('bridge uses the host from connection.json when present', async (t) => {
+    const TEST_PORT = 18768;
+    const TEST_TOKEN = 'e'.repeat(64);
+    const candidateHosts = ['127.0.0.2', '::1'];
+    let selectedHost = null;
+    let receivedHost = null;
+
+    const server = http.createServer((req, res) => {
+      receivedHost = req.socket.localAddress;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 101,
+        result: { tools: [{ name: 'remote-host' }] }
+      }));
+    });
+
+    for (const candidateHost of candidateHosts) {
+      try {
+        await new Promise((resolve, reject) => {
+          server.removeAllListeners('error');
+          server.once('error', reject);
+          server.listen(TEST_PORT, candidateHost, resolve);
+        });
+        selectedHost = candidateHost;
+        break;
+      } catch (err) {
+        if (!err || err.code !== 'EADDRNOTAVAIL') {
+          throw err;
+        }
+      }
+    }
+
+    if (!selectedHost) {
+      return t.skip(`no loopback alias available from: ${candidateHosts.join(', ')}`);
+    }
+
+    try {
+      writeTestConnectionInfo(TEST_PORT, TEST_TOKEN, { host: selectedHost });
+
+      const response = await sendToBridge({
+        jsonrpc: '2.0',
+        id: 101,
+        method: 'tools/list'
+      });
+
+      assert.equal(receivedHost, selectedHost);
+      assert.equal(response.id, 101);
+      assert.equal(response.result.tools[0].name, 'remote-host');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
   it('bridge fails closed when connection file is missing', async (t) => {
     if (await isPortInUse(DEFAULT_PORT)) {
       return t.skip('Thunderbird running on default port, skipping connection file removal test');
@@ -190,7 +244,7 @@ describe('Auth: connection info file', () => {
   });
 });
 
-describe('Auth: token verification', () => {
+describe('Auth: token verification', { concurrency: false }, () => {
   let server;
   const TEST_PORT = 18766;
   const CORRECT_TOKEN = 'b'.repeat(64);
@@ -284,7 +338,7 @@ function timingSafeEqual(a, b) {
   return result === 0;
 }
 
-describe('Timing-safe comparison: correctness', () => {
+describe('Timing-safe comparison: correctness', { concurrency: false }, () => {
   it('equal strings return true', () => {
     assert.equal(timingSafeEqual('abc', 'abc'), true);
   });
@@ -355,7 +409,7 @@ describe('Timing-safe comparison: correctness', () => {
 // CONNECTION FILE EDGE CASES
 // ═══════════════════════════════════════════════════════════════════
 
-describe('Auth: connection file corruption', () => {
+describe('Auth: connection file corruption', { concurrency: false }, () => {
   let thunderbirdRunning = false;
   before(async () => {
     thunderbirdRunning = await isPortInUse(DEFAULT_PORT);
@@ -574,7 +628,7 @@ describe('Auth: connection file corruption', () => {
 // BRIDGE LIFECYCLE & RETRY BEHAVIOR
 // ═══════════════════════════════════════════════════════════════════
 
-describe('Auth: bridge handles MCP lifecycle locally', () => {
+describe('Auth: bridge handles MCP lifecycle locally', { concurrency: false }, () => {
   // These methods are handled by the bridge directly without
   // contacting Thunderbird, so they should work even without
   // a connection file.
@@ -693,7 +747,7 @@ describe('Auth: bridge handles MCP lifecycle locally', () => {
   });
 });
 
-describe('Auth: bridge retry then fail', () => {
+describe('Auth: bridge retry then fail', { concurrency: false }, () => {
   let thunderbirdRunning = false;
   before(async () => {
     thunderbirdRunning = await isPortInUse(DEFAULT_PORT);

--- a/test/mcp-bridge.test.cjs
+++ b/test/mcp-bridge.test.cjs
@@ -10,7 +10,9 @@ const {
   compactToolResultJsonText,
   clearConnectionCache,
   discoverConnectionInfo,
+  getConnectionHosts,
   isValidAuthToken,
+  normalizeConnectionHost,
   readConnectionInfo,
 } = require('../mcp-bridge.cjs');
 
@@ -22,9 +24,9 @@ function cleanupTempRoot(root) {
   fs.rmSync(root, { recursive: true, force: true });
 }
 
-function writeConnectionFile(filePath, { port, token, pid = process.pid }) {
+function writeConnectionFile(filePath, { port, token, pid = process.pid, ...extraFields }) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify({ port, token, pid }), 'utf8');
+  fs.writeFileSync(filePath, JSON.stringify({ port, token, pid, ...extraFields }), 'utf8');
 }
 
 function makeTestOptions(root, overrides = {}) {
@@ -103,6 +105,27 @@ describe('Auth token validation', () => {
   });
 });
 
+describe('Connection host selection', () => {
+  it('uses localhost fallback hosts when connection.json does not specify a host', () => {
+    assert.deepStrictEqual(getConnectionHosts({ port: 8765, token: 'token' }), ['127.0.0.1']);
+  });
+
+  it('uses the explicit host from connection.json', () => {
+    assert.deepStrictEqual(getConnectionHosts({ host: 'remote-host', port: 8765, token: 'token' }), ['remote-host']);
+  });
+
+  it('normalizes bracketed IPv6 host values', () => {
+    assert.equal(normalizeConnectionHost('[::1]'), '::1');
+  });
+
+  it('rejects malformed host values', () => {
+    assert.throws(
+      () => getConnectionHosts({ host: 'http://remote-host', port: 8765, token: 'token' }),
+      /host must be a hostname or IP address/
+    );
+  });
+});
+
 describe('Tool result serialization', () => {
   it('compacts JSON text content without mutating the original response', () => {
     const originalText = JSON.stringify([{ name: 'INBOX', unreadMessages: 3 }], null, 2);
@@ -158,6 +181,26 @@ describe('Bridge discovery', () => {
 
     const connInfo = readConnectionInfo(options);
     assert.deepStrictEqual(connInfo, {
+      port: 20002,
+      token: 'env-token',
+      pid: process.pid,
+    });
+  });
+
+  it('preserves the optional host field from connection.json', () => {
+    const options = makeTestOptions(root, {
+      env: { THUNDERBIRD_MCP_CONNECTION_FILE: path.join(root, 'env', 'connection.json') },
+    });
+
+    writeConnectionFile(options.env.THUNDERBIRD_MCP_CONNECTION_FILE, {
+      host: 'remote-host',
+      port: 20002,
+      token: 'env-token',
+    });
+
+    const connInfo = readConnectionInfo(options);
+    assert.deepStrictEqual(connInfo, {
+      host: 'remote-host',
       port: 20002,
       token: 'env-token',
       pid: process.pid,


### PR DESCRIPTION
Adds support for remote hosts in connection.json by updating `mcp-bridge.cjs` to honor an optional host field in `connection.json` instead of always dialing `127.0.0.1`. The bridge now validates and normalizes host values, while preserving the existing localhost fallback when no host is specified.

Codex wrote the code and tests.

Tested that it works for me over LAN. :)