### PR TITLE
fix(compose): insert identity signature on direct-send paths

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -3568,6 +3568,157 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
             }
 
             /**
+             * Reads the identity's signature: either the sig_file on disk
+             * (attach_signature=true) or the inline htmlSigText.
+             *
+             * Returns { content, isHtmlSig } or null when the identity has none.
+             */
+            function readSignatureFileText(file) {
+              const fstream = Cc["@mozilla.org/network/file-input-stream;1"]
+                .createInstance(Ci.nsIFileInputStream);
+              const cstream = Cc["@mozilla.org/intl/converter-input-stream;1"]
+                .createInstance(Ci.nsIConverterInputStream);
+              try {
+                fstream.init(file, -1, 0, 0);
+                cstream.init(fstream, "UTF-8", 0, 0);
+                let data = "";
+                const chunk = {};
+                let read = 0;
+                do {
+                  read = cstream.readString(0xffffffff, chunk);
+                  data += chunk.value;
+                } while (read !== 0);
+                return data;
+              } finally {
+                try { cstream.close(); } catch (e) { /* already closed */ }
+              }
+            }
+
+            function getIdentitySignature(identity) {
+              if (!identity) return null;
+              try {
+                if (identity.attachSignature) {
+                  const file = identity.signature;
+                  if (file && file.exists() && file.isFile()) {
+                    const content = readSignatureFileText(file);
+                    if (content && content.trim()) {
+                      return { content, isHtmlSig: /\.html?$/i.test(file.leafName) };
+                    }
+                  }
+                }
+                const inline = identity.htmlSigText;
+                if (inline && inline.trim()) {
+                  return { content: inline, isHtmlSig: identity.htmlSigFormat === true };
+                }
+              } catch (error) {
+                console.warn("thunderbird-mcp: could not read identity signature", error);
+              }
+              return null;
+            }
+
+            /**
+             * Signatures are often stored as a whole document (htmlSigText from
+             * a signature generator keeps <!DOCTYPE><html><head>...). Embedding
+             * that inside our <body> would nest documents, so keep the body's
+             * inner HTML only -- which is what Thunderbird's compose editor
+             * effectively does when it inserts the signature.
+             */
+            function unwrapHtmlDocument(html) {
+              if (!/<(?:html|body|head)\b/i.test(html)) return html;
+
+              // NOTE: DOMParser is NOT reliably available in this ExtensionAPI
+              // scope (see the globals comment at the top of this file, and the
+              // stripHtml fallback in htmlToMarkdown). Guard on typeof -- a bare
+              // `new DOMParser()` throws ReferenceError, and swallowing it in a
+              // catch would silently return the document unwrapped.
+              try {
+                if (typeof DOMParser !== "undefined") {
+                  const doc = new DOMParser().parseFromString(html, "text/html");
+                  if (doc && doc.body) return doc.body.innerHTML;
+                }
+              } catch (error) {
+                console.warn("thunderbird-mcp: DOMParser unwrap failed, stripping envelope textually", error);
+              }
+
+              const body = /<body\b[^>]*>([\s\S]*)<\/body>/i.exec(html);
+              if (body) return body[1];
+              return html
+                .replace(/<!DOCTYPE[^>]*>/gi, "")
+                .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, "")
+                .replace(/<\/?(?:html|body)\b[^>]*>/gi, "");
+            }
+
+            function htmlSignatureToPlainText(html) {
+              try {
+                const parserUtils = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+                return parserUtils.convertToPlainText(
+                  html,
+                  Ci.nsIDocumentEncoder.OutputFormatted | Ci.nsIDocumentEncoder.OutputLFLineBreak,
+                  0
+                ).replace(/\s+$/, "");
+              } catch (error) {
+                console.warn("thunderbird-mcp: parserUtils unavailable, stripping tags", error);
+                return html.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]*>/g, "").trim();
+              }
+            }
+
+            /**
+             * Builds the trailing signature fragment for a body we compose
+             * ourselves.
+             *
+             * Thunderbird inserts signatures from its compose window only
+             * (gMsgCompose reads htmlSigText/sig_file and honours sig_bottom).
+             * The createAndSendMessage path behind saveDraft and skipReview
+             * sends never opens that window, so without this the message ships
+             * with no signature at all. New messages carry no quote, so
+             * sig_bottom does not apply: the signature always goes last.
+             *
+             * Returns "" when the identity has no signature.
+             */
+            function buildSignatureFragment(identity, useHtml) {
+              const sig = getIdentitySignature(identity);
+              if (!sig) return "";
+
+              const asText = sig.isHtmlSig ? htmlSignatureToPlainText(sig.content) : sig.content;
+              // Thunderbird prepends the "-- " separator unless the signature
+              // already opens with one (mail.compose.dont_add_signature_separator).
+              const hasSeparator = /^\s*--\s*$/m.test(asText.split("\n")[0] || "");
+
+              if (useHtml) {
+                const sigHtml = sig.isHtmlSig
+                  ? formatBodyHtml(unwrapHtmlDocument(sig.content), true)
+                  : formatBodyHtml(sig.content, false);
+                const separator = hasSeparator ? "" : "-- <br>";
+                return `<br><div class="moz-signature">${separator}${sigHtml}</div>`;
+              }
+
+              const separator = hasSeparator ? "" : "-- \n";
+              return `\n\n${separator}${asText}`;
+            }
+
+            /**
+             * Shapes composeFields.body for the direct-send paths, appending the
+             * identity signature. Mirrors the plain/HTML envelope rules used by
+             * the compose-window paths.
+             */
+            function buildBodyWithSignature(body, identity, useHtml, isHtml) {
+              const sigFragment = buildSignatureFragment(identity, useHtml);
+
+              if (!useHtml) {
+                return (body || "") + sigFragment;
+              }
+
+              const formatted = formatBodyHtml(body, isHtml);
+              if (isHtml && formatted.includes('<html')) {
+                if (!sigFragment) return formatted;
+                return /<\/body>/i.test(formatted)
+                  ? formatted.replace(/<\/body>/i, `${sigFragment}</body>`)
+                  : formatted + sigFragment;
+              }
+              return `<html><head><meta charset="UTF-8"></head><body>${formatted}${sigFragment}</body></html>`;
+            }
+
+            /**
              * Decides whether a compose operation will (or should) run in HTML
              * mode, and returns the matching msgComposeParams.format value.
              *
@@ -6483,6 +6634,11 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 const { descs: fileDescs, failed: failedPaths } = filePathsToAttachDescs(attachments);
 
                 if (skipReview) {
+                  // Direct send bypasses the compose window, so the identity
+                  // signature has to be appended here. The review path below
+                  // must NOT get it -- Thunderbird adds it when the window
+                  // opens, and doing both would duplicate it.
+                  composeFields.body = buildBodyWithSignature(body, msgComposeParams.identity, useHtml, isHtml);
                   return sendMessageDirectly(composeFields, msgComposeParams.identity, fileDescs, null, Ci.nsIMsgCompType.New, Ci.nsIMsgCompDeliverMode.Now, useHtml ? "text/html" : "text/plain").then(result => {
                     if (result.success) {
                       let msg = "Message sent";
@@ -6543,14 +6699,10 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
 
                 const { useHtml, format } = resolveComposeFormat(msgComposeParams.identity, isHtml, Ci.nsIMsgCompType.New);
                 msgComposeParams.format = format;
-                if (useHtml) {
-                  const formatted = formatBodyHtml(body, isHtml);
-                  composeFields.body = isHtml && formatted.includes('<html')
-                    ? formatted
-                    : `<html><head><meta charset="UTF-8"></head><body>${formatted}</body></html>`;
-                } else {
-                  composeFields.body = body || "";
-                }
+                // saveDraft always builds the message directly, so Thunderbird's
+                // compose window never runs and never inserts the signature --
+                // we have to append it ourselves.
+                composeFields.body = buildBodyWithSignature(body, msgComposeParams.identity, useHtml, isHtml);
 
                 const { descs: fileDescs, failed: failedPaths } = filePathsToAttachDescs(attachments);
 


### PR DESCRIPTION
## Problem

Messages created through `saveDraft` (and `sendMail` with `skipReview: true`) ship **without the identity's signature**, even when the identity has one configured and `sig_bottom` is set.

In practice this means a draft prepared over MCP is unusable as-is: you either reopen it in Thunderbird — which then inserts the signature at the *top* of the message, above the body — or you rewrite the mail by hand. On a plain-text draft the HTML signature additionally degrades to bare text, losing logos and formatting.

## Root cause

`saveDraft` and the `skipReview` branch of `composeMail` build the message directly via `sendMessageDirectly()` → `createAndSendMessage()`. Signature insertion is a **compose-window** feature: `gMsgCompose` reads `htmlSigText` / `sig_file` from the identity and honours `sig_bottom` when the window initialises. Those paths never open a window, so nothing ever inserts the signature — `api.js` has no reference to any signature pref today.

The compose-window paths (`composeMail` without `skipReview`, `replyToMessage`, `forwardMessage` in review mode) are unaffected: Thunderbird inserts the signature there itself.

## Fix

Read the signature off the resolved identity and append it to the body we compose ourselves, mirroring what the compose window does:

- **Source**: inline `htmlSigText`, or the `sig_file` on disk when `attach_signature` is set.
- **Separator**: `-- ` prepended unless the signature already opens with one.
- **HTML mode**: wrapped in `<div class="moz-signature">`.
- **Plain mode**: HTML signatures converted with `nsIParserUtils.convertToPlainText`, so links keep their URLs.
- **Placement**: always last. New messages carry no quote, so `sig_bottom` does not apply.

Two details worth calling out for reviewers:

1. **Signature documents are unwrapped.** Signature generators commonly store a whole document in `htmlSigText` (`<!DOCTYPE html><html><head>…`). Embedding that inside our `<body>` nests a second document in the message. The fix extracts the signature's body content first.

2. **`DOMParser` is not reliably available in this scope.** The globals comment at the top of `api.js` lists only `ExtensionCommon, ChromeUtils, Services, Cc, Ci`, and `htmlToMarkdown` already carries a "falls back to stripHtml if DOMParser is unavailable" path. A bare `new DOMParser()` throws `ReferenceError` here, and a `catch` around it silently returns the document un-unwrapped. The unwrap therefore guards on `typeof DOMParser !== "undefined"` and otherwise strips the envelope textually.

## Deliberately out of scope

`replyToMessage` and `forwardMessage` with `skipReview: true` have the same gap, but they need `sig_on_reply` / `sig_on_fwd` honoured and `sig_bottom` respected relative to the quote. That is a separate change; this PR does not touch them.

## Testing

Verified end-to-end against a real identity with a 45 KB HTML signature (inline `htmlSigText`, `htmlSigFormat=true`, `sig_bottom=true`) on Thunderbird 152 (Flatpak), by inspecting the raw source of the resulting drafts:

| | before | after |
|---|---|---|
| `<!DOCTYPE` in body | 1 | 0 |
| `<html` in body | 2 | 1 |
| `<body` in body | 2 | 1 |
| base64 logos preserved | 7 | 7 |
| signature after body text | — | yes |

- HTML draft: `Content-Type: text/html`, signature last, inside `moz-signature`, `-- <br>` separator, all inline images intact, non-ASCII entity-encoded.
- Plain draft: signature last, after `-- `, converted to text with link URLs preserved — byte-comparable to what Thunderbird's own compose window produces.
- The unwrap helper was additionally unit-tested offline against the real signature file: envelope removed, name/logos/legal footer all preserved, fragments without an envelope passed through unchanged, empty input safe.
- Existing test suite unaffected (`mcp-bridge`, `tool-access`, `validation`, `stress` pass; `auth` fails identically on a clean checkout, unrelated to this change).
