### PR TITLE
[AI-authored] getRecentMessages: include ccList in result rows like searchMessages

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -6986,6 +6986,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                       subject: msgHdr.mime2DecodedSubject || msgHdr.subject,
                       author: msgHdr.mime2DecodedAuthor || msgHdr.author,
                       recipients: msgHdr.mime2DecodedRecipients || msgHdr.recipients,
+                      ccList: msgHdr.ccList,
                       date: msgHdr.date ? new Date(msgHdr.date / 1000).toISOString() : null,
                       folder: folder.prettyName,
                       folderPath: folder.URI,


### PR DESCRIPTION
> ⚠️ **AI-authored PR** — This pull request was written by an AI coding assistant
> (Claude, via Claude Code) on behalf of @Gunther-Schulz. Please review with that
> in mind; happy to adjust anything.

## Summary
`getRecentMessages` omits `ccList` from its result rows; `searchMessages` includes
it. One line restores field parity.

## Problem
Both tools return rows for the same message, built by two separate object
literals. The `searchMessages` row builder carries `ccList: msgHdr.ccList`;
the `getRecentMessages` one has `subject` / `author` / `recipients` but no `cc`
field at all.

For a consumer that lists recent mail and reads the CC off the row, the field is
simply absent — which downstream reads as "this message has no CC", not as
"this surface doesn't answer that". The same message queried via
`searchMessages` shows the CC correctly, so the two surfaces disagree.

## Change
Adds `ccList: msgHdr.ccList` to the `getRecentMessages` row, in the same position
as in the `searchMessages` builder (after `recipients`, before `date`). Same
property name, same raw header value, no decoding difference — nothing else
touched.

## Notes
- Additive only: existing consumers see one extra field, no shape or value change
  to any field they already read.
- Test suite: **500 pass / 0 fail** (17 skipped) via `npm test`.
- `npm run lint` not run here — `eslint` isn't installed in my checkout.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
