### PR TITLE
[AI-authored] saveMessage: bridge-local .eml + attachment saving, gated default-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The Thunderbird extension embeds a local HTTP server with session-scoped auth to
 | `moveFolder` | Move a folder to a new parent within the same account |
 | `emptyTrash` | Permanently delete all messages in Trash (including subfolders) |
 | `emptyJunk` | Permanently delete all messages in Junk/Spam (including subfolders) |
+| `saveMessage` | Save a message's `.eml` and/or its attachments into a directory you choose (unlike `saveAttachments`, which is temp-dir only). Runs on the bridge, so the path is on the machine running the MCP. **Disabled unless `THUNDERBIRD_MCP_SAVE_MESSAGE=1`** -- see [Security](#security). |
 
 ### Compose
 
@@ -185,6 +186,22 @@ That's it. Your AI can now access Thunderbird.
 - **Tool access control**: Disable specific tools via the settings page. Disabled tools are hidden from `tools/list` and blocked at dispatch.
 - **Localhost only**: By default, the server binds to localhost only. The "Listen on all interfaces" option in settings binds to all IPv4 interfaces for WSL, Docker, or remote access. **This exposes the MCP server to every device on your local network.** Only enable on trusted networks. Auth token is always required.
 - **Auto-update integrity**: Auto-update is a code-delivery channel whose integrity depends on continued control of the GitHub repository, the GitHub Actions token, and the `tomaszkasperczyk.name` registration.
+- **Filesystem writes are opt-in**: `saveMessage` writes caller-named files to a caller-named directory, which is an arbitrary-write primitive in the hands of whatever drives the MCP -- a prompt-injected tool call could aim it at `~/.bashrc`, `~/.ssh/`, or an autostart entry. It is therefore off by default: hidden from `tools/list` and refused at dispatch unless `THUNDERBIRD_MCP_SAVE_MESSAGE=1` is set in the MCP server environment. Set `THUNDERBIRD_MCP_SAVE_ROOT=/path/to/dir` as well to confine every write inside one directory; destinations are resolved through symlinks before the check, so a link cannot escape the root. Saved files are created `0600` and new directories `0700`, and existing files are never written through a symlink.
+
+  ```json
+  {
+    "mcpServers": {
+      "thunderbird": {
+        "command": "npx",
+        "args": ["-y", "thunderbird-mcp"],
+        "env": {
+          "THUNDERBIRD_MCP_SAVE_MESSAGE": "1",
+          "THUNDERBIRD_MCP_SAVE_ROOT": "/home/you/Documents/mail-exports"
+        }
+      }
+    }
+  }
+  ```
 
 ---
 

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -784,6 +784,252 @@ async function inlineAttachmentPaths(args) {
   args.attachments = resolved;
 }
 
+// Bridge-local tool definition for saveMessage. The extension can only write
+// attachments into the OS temp dir and returns rawSource as text -- neither can
+// save to a caller-chosen path. The bridge already reads/writes host files, so
+// it owns this tool and injects it into tools/list; it is never forwarded to
+// the extension.
+const SAVE_MESSAGE_TOOL = {
+  name: 'saveMessage',
+  description: "Save a message to disk on the local machine: writes the full .eml and/or its attachments into a destination directory. Unlike saveAttachments (temp dir only), this writes to any path you choose. Runs on the bridge, so destDir is a path on the machine running the MCP.",
+  inputSchema: {
+    type: 'object',
+    properties: {
+      messageId: { type: 'string', description: 'Message ID (from searchMessages/getRecentMessages).' },
+      folderPath: { type: 'string', description: 'Folder URI path containing the message.' },
+      destDir: { type: 'string', description: 'Directory to write into (created recursively if missing).' },
+      saveEml: { type: 'boolean', description: 'Write the full raw .eml (default true).' },
+      saveAttachments: { type: 'boolean', description: 'Write attachments as loose files (default false).' },
+      emlFilename: { type: 'string', description: 'Filename for the .eml (default: sanitized subject from the raw headers, else messageId). ".eml" is appended if absent.' },
+      overwrite: { type: 'boolean', description: 'Overwrite existing files instead of erroring (default false).' }
+    },
+    required: ['messageId', 'folderPath', 'destDir']
+  }
+};
+
+// Unwrap a tools/call response envelope into its inner data object. Tool results
+// are shaped { result: { content: [ { type:'text', text:'<JSON>' } ] } }; a
+// tool-level failure comes back as { error } inside that JSON, which we surface
+// as a thrown Error so the caller reports it instead of silently continuing.
+function unwrapToolResponse(resp) {
+  const text = resp && resp.result && Array.isArray(resp.result.content)
+    ? resp.result.content[0] && resp.result.content[0].text
+    : undefined;
+  if (typeof text !== 'string') {
+    throw new Error('Unexpected tool response shape from getMessage');
+  }
+  const data = JSON.parse(text);
+  if (data && data.error) {
+    throw new Error(data.error);
+  }
+  return data;
+}
+
+// Turn an arbitrary name into a safe single-path-segment filename: drop path
+// separators and control chars, collapse whitespace, and refuse names that
+// would be empty or traverse ('.'/'..'). Spaces, unicode, and parentheses are
+// kept -- they appear in real-world filenames.
+function sanitizeSaveFilename(name) {
+  let s = String(name == null ? '' : name);
+  // eslint-disable-next-line no-control-regex
+  s = s.replace(/[/\\\x00-\x1f\x7f]/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+  if (!s || s === '.' || s === '..') {
+    throw new Error(`Cannot derive a safe filename from ${JSON.stringify(String(name))}`);
+  }
+  return s;
+}
+
+// Best-effort MIME encoded-word decoder (RFC 2047) for building a nicer .eml
+// filename from a Subject header. Anything it can't decode is left untouched.
+function decodeMimeEncodedWords(input) {
+  try {
+    return String(input).replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (match, charset, enc, text) => {
+      let buf;
+      if (enc.toUpperCase() === 'B') {
+        buf = Buffer.from(text, 'base64');
+      } else {
+        const bytes = [];
+        for (let i = 0; i < text.length; i++) {
+          const ch = text[i];
+          if (ch === '_') {
+            bytes.push(0x20);
+          } else if (ch === '=' && i + 2 < text.length) {
+            bytes.push(parseInt(text.substr(i + 1, 2), 16));
+            i += 2;
+          } else {
+            bytes.push(ch.charCodeAt(0));
+          }
+        }
+        buf = Buffer.from(bytes);
+      }
+      const cs = charset.toLowerCase();
+      const encoding = (cs === 'iso-8859-1' || cs === 'latin1' || cs === 'us-ascii' || cs === 'ascii')
+        ? 'latin1'
+        : 'utf8';
+      return buf.toString(encoding);
+    });
+  } catch {
+    return input;
+  }
+}
+
+// Parse the first Subject header out of a raw RFC822 message, unfolding any
+// continuation lines. Returns null when there is no Subject in the header block.
+function subjectFromRawSource(raw) {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const lines = raw.split(/\r\n|\r|\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Headers end at the first blank line.
+    if (line === '') {
+      break;
+    }
+    const m = /^Subject:[ \t]?(.*)$/i.exec(line);
+    if (m) {
+      let value = m[1];
+      while (i + 1 < lines.length && /^[ \t]/.test(lines[i + 1])) {
+        value += ' ' + lines[i + 1].replace(/^[ \t]+/, '');
+        i++;
+      }
+      value = value.trim();
+      return value || null;
+    }
+  }
+  return null;
+}
+
+// Pick a destination filename that does not collide with an existing file or
+// one already written this run. Only suffixes ' (2)', ' (3)', ... before the
+// extension when overwrite is off; with overwrite on the base name is used.
+function uniqueDestName(destDir, baseName, usedNames, overwrite, fsImpl, pathImpl) {
+  if (overwrite) {
+    return baseName;
+  }
+  const collides = (name) =>
+    usedNames.has(name) || fsImpl.existsSync(pathImpl.join(destDir, name));
+  if (!collides(baseName)) {
+    return baseName;
+  }
+  const ext = pathImpl.extname(baseName);
+  const stem = baseName.slice(0, baseName.length - ext.length);
+  let n = 2;
+  let candidate;
+  do {
+    candidate = `${stem} (${n})${ext}`;
+    n++;
+  } while (collides(candidate));
+  return candidate;
+}
+
+// Write a message's .eml and/or attachments into a caller-chosen directory on
+// the host filesystem. fetchMessage(subMessage) returns the parsed JSON-RPC
+// response for a tools/call (forwardToThunderbird in production, a mock in
+// tests). Returns the inner data object { emlPath, attachments, skippedAttachments,
+// destDir }; the handleMessage caller wraps it into the MCP content envelope.
+async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = path }) {
+  args = args || {};
+  const { messageId, folderPath, destDir } = args;
+  if (typeof messageId !== 'string' || !messageId.trim()) {
+    throw new Error('saveMessage requires a non-empty messageId string');
+  }
+  if (typeof folderPath !== 'string' || !folderPath.trim()) {
+    throw new Error('saveMessage requires a non-empty folderPath string');
+  }
+  if (typeof destDir !== 'string' || !destDir.trim()) {
+    throw new Error('saveMessage requires a non-empty destDir string');
+  }
+
+  const overwrite = args.overwrite === true;
+  const writeEml = args.saveEml !== false;
+  const writeAttachments = args.saveAttachments === true;
+
+  fsImpl.mkdirSync(destDir, { recursive: true });
+
+  let emlPath = null;
+
+  if (writeEml) {
+    const resp = await fetchMessage({
+      jsonrpc: '2.0',
+      id: 'saveMessage-eml',
+      method: 'tools/call',
+      params: {
+        name: 'getMessage',
+        arguments: { messageId, folderPath, rawSource: true }
+      }
+    });
+    const data = unwrapToolResponse(resp);
+    const rawSource = data.rawSource;
+    if (typeof rawSource !== 'string' || rawSource.length === 0) {
+      throw new Error(
+        'getMessage returned no rawSource; saving the .eml requires a local/offline ' +
+        'copy of the message (IMAP messages not cached offline cannot be read).'
+      );
+    }
+
+    let filename;
+    if (typeof args.emlFilename === 'string' && args.emlFilename.trim()) {
+      filename = args.emlFilename;
+    } else {
+      const subject = subjectFromRawSource(rawSource);
+      filename = subject ? decodeMimeEncodedWords(subject) : messageId;
+    }
+    filename = sanitizeSaveFilename(filename);
+    if (!/\.eml$/i.test(filename)) {
+      filename += '.eml';
+    }
+
+    const fullPath = pathImpl.join(destDir, filename);
+    try {
+      fsImpl.writeFileSync(fullPath, rawSource, {
+        encoding: 'utf8',
+        flag: overwrite ? 'w' : 'wx'
+      });
+    } catch (e) {
+      if (e.code === 'EEXIST') {
+        throw new Error(`File already exists: ${fullPath} (set overwrite:true to replace it)`);
+      }
+      throw e;
+    }
+    emlPath = fullPath;
+  }
+
+  const writtenAttachments = [];
+  const skippedAttachments = [];
+
+  if (writeAttachments) {
+    const resp = await fetchMessage({
+      jsonrpc: '2.0',
+      id: 'saveMessage-attachments',
+      method: 'tools/call',
+      params: {
+        name: 'getMessage',
+        arguments: { messageId, folderPath, saveAttachments: true }
+      }
+    });
+    const data = unwrapToolResponse(resp);
+    const attachments = Array.isArray(data.attachments) ? data.attachments : [];
+    const usedNames = new Set();
+    for (const att of attachments) {
+      const srcPath = att && att.filePath;
+      if (typeof srcPath !== 'string' || !srcPath) {
+        skippedAttachments.push((att && att.name) || null);
+        continue;
+      }
+      const baseName = sanitizeSaveFilename(att.name || pathImpl.basename(srcPath));
+      const destName = uniqueDestName(destDir, baseName, usedNames, overwrite, fsImpl, pathImpl);
+      const destPath = pathImpl.join(destDir, destName);
+      fsImpl.copyFileSync(srcPath, destPath);
+      usedNames.add(destName);
+      writtenAttachments.push(destPath);
+    }
+  }
+
+  return { emlPath, attachments: writtenAttachments, skippedAttachments, destDir };
+}
+
 /**
  * Read connection info (port + auth token) written by the Thunderbird extension.
  * Returns { port, token } or null if no valid candidate exists.
@@ -926,6 +1172,41 @@ async function handleMessage(line) {
       && ATTACHMENT_TOOLS.has(message.params.name)) {
     try {
       await inlineAttachmentPaths(message.params.arguments);
+    } catch (e) {
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32602, message: e.message }
+      };
+    }
+  }
+
+  // tools/list: forward to the extension, then append the bridge-local tools it
+  // doesn't know about (saveMessage runs here, not in the extension). Guard the
+  // shape so a malformed extension response is returned untouched.
+  if (message.method === 'tools/list') {
+    const resp = await forwardToThunderbird(message);
+    if (resp && resp.result && Array.isArray(resp.result.tools)) {
+      resp.result.tools.push(SAVE_MESSAGE_TOOL);
+    }
+    return resp;
+  }
+
+  // saveMessage is a bridge-local tool that writes files on the machine running
+  // the MCP. Handle it here so it is never forwarded to the extension.
+  if (message.method === 'tools/call'
+      && message.params
+      && message.params.name === 'saveMessage') {
+    try {
+      const data = await saveMessageToDisk({
+        args: message.params.arguments || {},
+        fetchMessage: forwardToThunderbird
+      });
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { content: [{ type: 'text', text: JSON.stringify(data) }] }
+      };
     } catch (e) {
       return {
         jsonrpc: '2.0',
@@ -1216,6 +1497,8 @@ module.exports = {
   isSensitiveFilePath,
   isValidAuthToken,
   readConnectionInfo,
+  SAVE_MESSAGE_TOOL,
+  saveMessageToDisk,
   startBridge,
   attachmentLimits: {
     MAX_ATTACHMENT_BYTES,

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -800,12 +800,82 @@ const SAVE_MESSAGE_TOOL = {
       destDir: { type: 'string', description: 'Directory to write into (created recursively if missing).' },
       saveEml: { type: 'boolean', description: 'Write the full raw .eml (default true).' },
       saveAttachments: { type: 'boolean', description: 'Write attachments as loose files (default false).' },
-      emlFilename: { type: 'string', description: 'Filename for the .eml (default: sanitized subject from the raw headers, else messageId). ".eml" is appended if absent.' },
+      emlFilename: { type: 'string', description: 'Filename for the .eml (default: the sanitized message subject, else messageId). ".eml" is appended if absent.' },
       overwrite: { type: 'boolean', description: 'Overwrite existing files instead of erroring (default false).' }
     },
     required: ['messageId', 'folderPath', 'destDir']
   }
 };
+
+// saveMessage hands whatever drives this MCP an arbitrary filesystem-write
+// primitive: attacker-supplied attachment bytes at an attacker-supplied path.
+// A prompt-injected tool call could target ~/.bashrc, ~/.ssh/, or an autostart
+// entry. So the tool is opt-in -- absent from tools/list and refused on
+// tools/call unless THUNDERBIRD_MCP_SAVE_MESSAGE=1 -- and can be narrowed
+// further by THUNDERBIRD_MCP_SAVE_ROOT, which destDir must resolve inside.
+const SAVE_MESSAGE_ENV = 'THUNDERBIRD_MCP_SAVE_MESSAGE';
+const SAVE_ROOT_ENV = 'THUNDERBIRD_MCP_SAVE_ROOT';
+
+// Directories get 0700 and files 0600: saved mail is private, and under a
+// normal umask node would otherwise create them world-readable.
+const SAVE_DIR_MODE = 0o700;
+const SAVE_FILE_MODE = 0o600;
+
+function saveMessageEnabled(env = process.env) {
+  return env[SAVE_MESSAGE_ENV] === '1';
+}
+
+function saveMessageRoot(env = process.env) {
+  const raw = env[SAVE_ROOT_ENV];
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+}
+
+// Resolve a path to its real location even when it does not exist yet: walk up
+// to the nearest existing ancestor, realpath *that* (which is what defeats a
+// symlinked intermediate directory), then re-append the missing tail. Resolving
+// only the existing prefix is the point -- realpathSync on the full path throws
+// ENOENT for a directory we are about to create.
+function resolveIntendedPath(target, fsImpl, pathImpl) {
+  const abs = pathImpl.resolve(target);
+  const missing = [];
+  let cursor = abs;
+  for (;;) {
+    try {
+      const real = fsImpl.realpathSync(cursor);
+      return missing.length ? pathImpl.join(real, ...missing.reverse()) : real;
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+      const parent = pathImpl.dirname(cursor);
+      if (parent === cursor) {
+        return abs;
+      }
+      missing.push(pathImpl.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+// Resolve destDir through any symlinks and, when a save root is configured,
+// refuse anything outside it. Returns the resolved directory, which is what
+// every later path operation uses -- checking the caller's spelling and then
+// writing to the unresolved path would leave the symlink hole open.
+function resolveDestDir(destDir, { env = process.env, fsImpl = fs, pathImpl = path } = {}) {
+  const resolved = resolveIntendedPath(destDir, fsImpl, pathImpl);
+  const root = saveMessageRoot(env);
+  if (!root) {
+    return resolved;
+  }
+  const realRoot = resolveIntendedPath(root, fsImpl, pathImpl);
+  const rel = pathImpl.relative(realRoot, resolved);
+  if (rel !== '' && (rel.startsWith('..') || pathImpl.isAbsolute(rel))) {
+    throw new Error(
+      `destDir resolves to ${resolved}, which is outside ${SAVE_ROOT_ENV} (${realRoot})`
+    );
+  }
+  return resolved;
+}
 
 // Unwrap a tools/call response envelope into its inner data object. Tool results
 // are shaped { result: { content: [ { type:'text', text:'<JSON>' } ] } }; a
@@ -825,103 +895,82 @@ function unwrapToolResponse(resp) {
   return data;
 }
 
+// Windows device names are reserved at every directory level and with any
+// extension: CON, COM3.txt and PRN.eml all resolve to the device, not a file.
+const WINDOWS_RESERVED_STEM = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
+
 // Turn an arbitrary name into a safe single-path-segment filename: drop path
-// separators and control chars, collapse whitespace, and refuse names that
-// would be empty or traverse ('.'/'..'). Spaces, unicode, and parentheses are
-// kept -- they appear in real-world filenames.
+// separators, control chars and the characters Windows forbids (which also
+// closes NTFS alternate-data-stream names, since those need the colon),
+// collapse whitespace, strip the trailing dots and spaces Windows silently
+// discards, and refuse names that would be empty or traverse ('.'/'..').
+// Spaces, unicode, and parentheses are kept -- they appear in real filenames.
 function sanitizeSaveFilename(name) {
   let s = String(name == null ? '' : name);
   // eslint-disable-next-line no-control-regex
-  s = s.replace(/[/\\\x00-\x1f\x7f]/g, ' ');
+  s = s.replace(/[/\\\x00-\x1f\x7f<>:"|?*]/g, ' ');
   s = s.replace(/\s+/g, ' ').trim();
+  // Do this after trimming: ' .. ' and 'foo...' both need it, and a name of
+  // nothing but dots must collapse to empty so the guard below rejects it.
+  s = s.replace(/[. ]+$/, '');
   if (!s || s === '.' || s === '..') {
     throw new Error(`Cannot derive a safe filename from ${JSON.stringify(String(name))}`);
+  }
+  const stem = s.replace(/\..*$/, '');
+  if (WINDOWS_RESERVED_STEM.test(stem)) {
+    s = `_${s}`;
   }
   return s;
 }
 
-// Best-effort MIME encoded-word decoder (RFC 2047) for building a nicer .eml
-// filename from a Subject header. Anything it can't decode is left untouched.
-function decodeMimeEncodedWords(input) {
-  try {
-    return String(input).replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (match, charset, enc, text) => {
-      let buf;
-      if (enc.toUpperCase() === 'B') {
-        buf = Buffer.from(text, 'base64');
-      } else {
-        const bytes = [];
-        for (let i = 0; i < text.length; i++) {
-          const ch = text[i];
-          if (ch === '_') {
-            bytes.push(0x20);
-          } else if (ch === '=' && i + 2 < text.length) {
-            bytes.push(parseInt(text.substr(i + 1, 2), 16));
-            i += 2;
-          } else {
-            bytes.push(ch.charCodeAt(0));
-          }
-        }
-        buf = Buffer.from(bytes);
-      }
-      const cs = charset.toLowerCase();
-      const encoding = (cs === 'iso-8859-1' || cs === 'latin1' || cs === 'us-ascii' || cs === 'ascii')
-        ? 'latin1'
-        : 'utf8';
-      return buf.toString(encoding);
-    });
-  } catch {
-    return input;
-  }
-}
-
-// Parse the first Subject header out of a raw RFC822 message, unfolding any
-// continuation lines. Returns null when there is no Subject in the header block.
-function subjectFromRawSource(raw) {
-  if (typeof raw !== 'string') {
-    return null;
-  }
-  const lines = raw.split(/\r\n|\r|\n/);
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Headers end at the first blank line.
-    if (line === '') {
-      break;
-    }
-    const m = /^Subject:[ \t]?(.*)$/i.exec(line);
-    if (m) {
-      let value = m[1];
-      while (i + 1 < lines.length && /^[ \t]/.test(lines[i + 1])) {
-        value += ' ' + lines[i + 1].replace(/^[ \t]+/, '');
-        i++;
-      }
-      value = value.trim();
-      return value || null;
-    }
-  }
-  return null;
-}
-
-// Pick a destination filename that does not collide with an existing file or
-// one already written this run. Only suffixes ' (2)', ' (3)', ... before the
-// extension when overwrite is off; with overwrite on the base name is used.
-function uniqueDestName(destDir, baseName, usedNames, overwrite, fsImpl, pathImpl) {
-  if (overwrite) {
-    return baseName;
-  }
-  const collides = (name) =>
-    usedNames.has(name) || fsImpl.existsSync(pathImpl.join(destDir, name));
-  if (!collides(baseName)) {
-    return baseName;
-  }
+// Generate ' (2)', ' (3)', ... variants of a filename, suffixed before the
+// extension. Yields the base name first.
+function* collisionCandidates(baseName, pathImpl) {
+  yield baseName;
   const ext = pathImpl.extname(baseName);
   const stem = baseName.slice(0, baseName.length - ext.length);
-  let n = 2;
-  let candidate;
-  do {
-    candidate = `${stem} (${n})${ext}`;
-    n++;
-  } while (collides(candidate));
-  return candidate;
+  for (let n = 2; ; n++) {
+    yield `${stem} (${n})${ext}`;
+  }
+}
+
+// Remove an existing entry so a subsequent exclusive create lands on a fresh
+// file. Used only in overwrite mode, and it is what makes overwrite no-follow:
+// unlinking a symlink removes the link, so the create that follows cannot be
+// redirected through it.
+function unlinkForOverwrite(destPath, fsImpl) {
+  fsImpl.rmSync(destPath, { force: true });
+}
+
+// Copy an attachment out of the extension's temp dir, never following a
+// symlink planted at the destination and never racing an existence check: the
+// exclusive create *is* the check. Retries the ' (n)' suffix on collision
+// unless overwrite is on, in which case the existing entry is unlinked first.
+// COPYFILE_EXCL is the copy-side equivalent of 'wx':
+// without it copyFileSync happily follows and overwrites a symlink planted at
+// the destination, which is exactly what `overwrite: false` promises not to do.
+function copyFileExclusive(srcPath, destDir, baseName, { usedNames, overwrite, fsImpl, pathImpl }) {
+  for (const candidate of collisionCandidates(baseName, pathImpl)) {
+    if (usedNames.has(candidate)) {
+      continue;
+    }
+    const destPath = pathImpl.join(destDir, candidate);
+    try {
+      fsImpl.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
+    } catch (e) {
+      if (e.code !== 'EEXIST') {
+        throw e;
+      }
+      if (!overwrite) {
+        continue;
+      }
+      unlinkForOverwrite(destPath, fsImpl);
+      fsImpl.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
+    }
+    fsImpl.chmodSync(destPath, SAVE_FILE_MODE);
+    usedNames.add(candidate);
+    return destPath;
+  }
 }
 
 // Write a message's .eml and/or attachments into a caller-chosen directory on
@@ -929,16 +978,22 @@ function uniqueDestName(destDir, baseName, usedNames, overwrite, fsImpl, pathImp
 // response for a tools/call (forwardToThunderbird in production, a mock in
 // tests). Returns the inner data object { emlPath, attachments, skippedAttachments,
 // destDir }; the handleMessage caller wraps it into the MCP content envelope.
-async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = path }) {
+async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = path, env = process.env }) {
   args = args || {};
-  const { messageId, folderPath, destDir } = args;
+  if (!saveMessageEnabled(env)) {
+    throw new Error(
+      `saveMessage is disabled. Set ${SAVE_MESSAGE_ENV}=1 in the MCP server environment ` +
+      `to enable writing files to disk (optionally with ${SAVE_ROOT_ENV} to confine them).`
+    );
+  }
+  const { messageId, folderPath } = args;
   if (typeof messageId !== 'string' || !messageId.trim()) {
     throw new Error('saveMessage requires a non-empty messageId string');
   }
   if (typeof folderPath !== 'string' || !folderPath.trim()) {
     throw new Error('saveMessage requires a non-empty folderPath string');
   }
-  if (typeof destDir !== 'string' || !destDir.trim()) {
+  if (typeof args.destDir !== 'string' || !args.destDir.trim()) {
     throw new Error('saveMessage requires a non-empty destDir string');
   }
 
@@ -946,8 +1001,16 @@ async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = p
   const writeEml = args.saveEml !== false;
   const writeAttachments = args.saveAttachments === true;
 
-  fsImpl.mkdirSync(destDir, { recursive: true });
+  // Resolve before creating: a symlinked ancestor must be followed to its real
+  // location and checked against the save root *first*, or the root check
+  // guards a path nothing is ever written to.
+  const destDir = resolveDestDir(args.destDir, { env, fsImpl, pathImpl });
+  fsImpl.mkdirSync(destDir, { recursive: true, mode: SAVE_DIR_MODE });
 
+  // Shared across the .eml and the attachments so a second file can never take
+  // a name already written this run -- including the .eml's own name, which
+  // under the previous overwrite behavior an attachment could clobber.
+  const usedNames = new Set();
   let emlPath = null;
 
   if (writeEml) {
@@ -973,26 +1036,44 @@ async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = p
     if (typeof args.emlFilename === 'string' && args.emlFilename.trim()) {
       filename = args.emlFilename;
     } else {
-      const subject = subjectFromRawSource(rawSource);
-      filename = subject ? decodeMimeEncodedWords(subject) : messageId;
+      // data.subject arrives already RFC 2047-decoded from Thunderbird
+      // (mime2DecodedSubject), so there is nothing left for the bridge to
+      // decode -- and nothing to parse back out of the raw headers.
+      filename = typeof data.subject === 'string' && data.subject.trim()
+        ? data.subject
+        : messageId;
     }
     filename = sanitizeSaveFilename(filename);
     if (!/\.eml$/i.test(filename)) {
       filename += '.eml';
     }
 
+    // rawSource is a Latin-1 byte string: the extension reads the message as
+    // bytes and hands each one over as a code point. Writing it as UTF-8 would
+    // re-encode every byte above 0x7f into two, corrupting 8-bit bodies, MIME
+    // parts and signatures. Convert back to the original bytes instead.
+    const emlBytes = Buffer.from(rawSource, 'latin1');
+
+    // The .eml does not get a ' (2)' suffix the way attachments do -- a caller
+    // naming the file expects that name or an error. The exclusive create is
+    // the existence check, so there is no window to lose.
     const fullPath = pathImpl.join(destDir, filename);
     try {
-      fsImpl.writeFileSync(fullPath, rawSource, {
-        encoding: 'utf8',
-        flag: overwrite ? 'w' : 'wx'
-      });
+      fsImpl.writeFileSync(fullPath, emlBytes, { flag: 'wx', mode: SAVE_FILE_MODE });
     } catch (e) {
-      if (e.code === 'EEXIST') {
-        throw new Error(`File already exists: ${fullPath} (set overwrite:true to replace it)`);
+      if (e.code !== 'EEXIST') {
+        throw e;
       }
-      throw e;
+      if (!overwrite) {
+        throw new Error(
+          `File already exists: ${fullPath} (set overwrite:true to replace it)`,
+          { cause: e }
+        );
+      }
+      unlinkForOverwrite(fullPath, fsImpl);
+      fsImpl.writeFileSync(fullPath, emlBytes, { flag: 'wx', mode: SAVE_FILE_MODE });
     }
+    usedNames.add(filename);
     emlPath = fullPath;
   }
 
@@ -1011,7 +1092,6 @@ async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = p
     });
     const data = unwrapToolResponse(resp);
     const attachments = Array.isArray(data.attachments) ? data.attachments : [];
-    const usedNames = new Set();
     for (const att of attachments) {
       const srcPath = att && att.filePath;
       if (typeof srcPath !== 'string' || !srcPath) {
@@ -1019,11 +1099,9 @@ async function saveMessageToDisk({ args, fetchMessage, fsImpl = fs, pathImpl = p
         continue;
       }
       const baseName = sanitizeSaveFilename(att.name || pathImpl.basename(srcPath));
-      const destName = uniqueDestName(destDir, baseName, usedNames, overwrite, fsImpl, pathImpl);
-      const destPath = pathImpl.join(destDir, destName);
-      fsImpl.copyFileSync(srcPath, destPath);
-      usedNames.add(destName);
-      writtenAttachments.push(destPath);
+      writtenAttachments.push(
+        copyFileExclusive(srcPath, destDir, baseName, { usedNames, overwrite, fsImpl, pathImpl })
+      );
     }
   }
 
@@ -1115,7 +1193,9 @@ function sanitizeJson(data) {
   return sanitized;
 }
 
-async function handleMessage(line) {
+// deps is a seam for tests: production passes nothing and gets the real
+// transport and the process environment.
+async function handleMessage(line, { forward = forwardToThunderbird, env = process.env } = {}) {
   const message = JSON.parse(line);
   const hasId = Object.prototype.hasOwnProperty.call(message, 'id');
   const isNotification =
@@ -1184,9 +1264,11 @@ async function handleMessage(line) {
   // tools/list: forward to the extension, then append the bridge-local tools it
   // doesn't know about (saveMessage runs here, not in the extension). Guard the
   // shape so a malformed extension response is returned untouched.
+  // saveMessage is advertised only when explicitly enabled -- a disabled tool
+  // the model cannot see is a tool prompt injection cannot reach for.
   if (message.method === 'tools/list') {
-    const resp = await forwardToThunderbird(message);
-    if (resp && resp.result && Array.isArray(resp.result.tools)) {
+    const resp = await forward(message);
+    if (saveMessageEnabled(env) && resp && resp.result && Array.isArray(resp.result.tools)) {
       resp.result.tools.push(SAVE_MESSAGE_TOOL);
     }
     return resp;
@@ -1200,7 +1282,8 @@ async function handleMessage(line) {
     try {
       const data = await saveMessageToDisk({
         args: message.params.arguments || {},
-        fetchMessage: forwardToThunderbird
+        fetchMessage: forward,
+        env
       });
       return {
         jsonrpc: '2.0',
@@ -1493,11 +1576,17 @@ module.exports = {
   findSnapConnectionCandidates,
   formatDiscoveryAttempts,
   compactToolResultJsonText,
+  handleMessage,
   inlineAttachmentPaths,
   isSensitiveFilePath,
   isValidAuthToken,
   readConnectionInfo,
+  resolveDestDir,
+  sanitizeSaveFilename,
+  SAVE_MESSAGE_ENV,
   SAVE_MESSAGE_TOOL,
+  SAVE_ROOT_ENV,
+  saveMessageEnabled,
   saveMessageToDisk,
   startBridge,
   attachmentLimits: {

--- a/test/save-message.test.cjs
+++ b/test/save-message.test.cjs
@@ -1,0 +1,253 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { saveMessageToDisk } = require('../mcp-bridge.cjs');
+
+// Tracks temp dirs created during a test so afterEach can remove them.
+let tempDirs = [];
+
+function mkTemp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tb-mcp-save-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// Wrap a tool's data object in the JSON-RPC/content envelope the bridge expects
+// (the same shape forwardToThunderbird returns for a tools/call).
+function makeEnvelope(data) {
+  return {
+    jsonrpc: '2.0',
+    id: 'mock',
+    result: { content: [{ type: 'text', text: JSON.stringify(data) }] }
+  };
+}
+
+describe('saveMessageToDisk', () => {
+  beforeEach(() => {
+    tempDirs = [];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it('writes the .eml with the exact rawSource and a subject-derived filename', async () => {
+    const dir = mkTemp();
+    const raw = 'Subject: Hello World\r\nFrom: a@b.com\r\n\r\nBody line one\r\nBody line two\r\n';
+
+    let seenArgs = null;
+    const fetchMessage = async (sub) => {
+      seenArgs = sub.params.arguments;
+      return makeEnvelope({ rawSource: raw });
+    };
+
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-1', folderPath: 'imap://x/INBOX', destDir: dir },
+      fetchMessage
+    });
+
+    assert.equal(seenArgs.rawSource, true);
+    assert.equal(seenArgs.messageId, 'mid-1');
+    const expected = path.join(dir, 'Hello World.eml');
+    assert.equal(result.emlPath, expected);
+    assert.equal(fs.readFileSync(expected, 'utf8'), raw);
+    assert.deepEqual(result.attachments, []);
+    assert.deepEqual(result.skippedAttachments, []);
+    assert.equal(result.destDir, dir);
+  });
+
+  it('unfolds a multi-line Subject header when deriving the filename', async () => {
+    const dir = mkTemp();
+    const raw = 'From: a@b.com\r\nSubject: First part\r\n continued part\r\n\r\nbody';
+
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-2', folderPath: 'fp', destDir: dir },
+      fetchMessage
+    });
+
+    assert.equal(result.emlPath, path.join(dir, 'First part continued part.eml'));
+    assert.ok(fs.existsSync(result.emlPath));
+  });
+
+  it('honors emlFilename and appends .eml when absent', async () => {
+    const dir = mkTemp();
+    const raw = 'Subject: Ignored Subject\r\n\r\nbody';
+
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-3', folderPath: 'fp', destDir: dir, emlFilename: 'custom-name' },
+      fetchMessage
+    });
+
+    assert.equal(result.emlPath, path.join(dir, 'custom-name.eml'));
+    assert.equal(fs.readFileSync(result.emlPath, 'utf8'), raw);
+  });
+
+  it('falls back to messageId when there is no Subject header', async () => {
+    const dir = mkTemp();
+    const raw = 'From: a@b.com\r\n\r\nbody without a subject';
+
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
+    const result = await saveMessageToDisk({
+      args: { messageId: 'fallback-id', folderPath: 'fp', destDir: dir },
+      fetchMessage
+    });
+
+    assert.equal(result.emlPath, path.join(dir, 'fallback-id.eml'));
+  });
+
+  it('creates a missing nested destDir', async () => {
+    const dir = path.join(mkTemp(), 'a', 'b', 'c');
+    const raw = 'Subject: Nested\r\n\r\nbody';
+
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-4', folderPath: 'fp', destDir: dir },
+      fetchMessage
+    });
+
+    assert.ok(fs.existsSync(dir));
+    assert.equal(result.emlPath, path.join(dir, 'Nested.eml'));
+    assert.ok(fs.existsSync(result.emlPath));
+  });
+
+  it('overwrite:false throws on an existing file, overwrite:true replaces it', async () => {
+    const dir = mkTemp();
+    const raw1 = 'Subject: Dup\r\n\r\nfirst';
+    const raw2 = 'Subject: Dup\r\n\r\nsecond';
+
+    const fetchFirst = async () => makeEnvelope({ rawSource: raw1 });
+    const first = await saveMessageToDisk({
+      args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir },
+      fetchMessage: fetchFirst
+    });
+    assert.equal(fs.readFileSync(first.emlPath, 'utf8'), raw1);
+
+    const fetchSecond = async () => makeEnvelope({ rawSource: raw2 });
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir },
+        fetchMessage: fetchSecond
+      }),
+      /already exists/
+    );
+    // The failed non-overwrite write must not have clobbered the original.
+    assert.equal(fs.readFileSync(first.emlPath, 'utf8'), raw1);
+
+    const replaced = await saveMessageToDisk({
+      args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir, overwrite: true },
+      fetchMessage: fetchSecond
+    });
+    assert.equal(replaced.emlPath, first.emlPath);
+    assert.equal(fs.readFileSync(replaced.emlPath, 'utf8'), raw2);
+  });
+
+  it('copies attachments into destDir by name, suffixes collisions, and skips path-less entries', async () => {
+    const dir = mkTemp();
+    const srcDir = mkTemp();
+    const src1 = path.join(srcDir, 'temp-a.bin');
+    const src2 = path.join(srcDir, 'temp-b.bin');
+    fs.writeFileSync(src1, 'AAA');
+    fs.writeFileSync(src2, 'BBB');
+
+    const fetchMessage = async (sub) => {
+      assert.equal(sub.params.arguments.saveAttachments, true);
+      return makeEnvelope({
+        attachments: [
+          { name: 'report.pdf', filePath: src1, contentType: 'application/pdf', size: 3 },
+          { name: 'report.pdf', filePath: src2, contentType: 'application/pdf', size: 3 },
+          { name: 'inline-only.txt' }
+        ]
+      });
+    };
+
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-6', folderPath: 'fp', destDir: dir, saveEml: false, saveAttachments: true },
+      fetchMessage
+    });
+
+    const p1 = path.join(dir, 'report.pdf');
+    const p2 = path.join(dir, 'report (2).pdf');
+    assert.deepEqual(result.attachments, [p1, p2]);
+    assert.equal(fs.readFileSync(p1, 'utf8'), 'AAA');
+    assert.equal(fs.readFileSync(p2, 'utf8'), 'BBB');
+    assert.deepEqual(result.skippedAttachments, ['inline-only.txt']);
+    assert.equal(result.emlPath, null);
+  });
+
+  it('writes both the .eml and attachments in one call', async () => {
+    const dir = mkTemp();
+    const srcDir = mkTemp();
+    const src1 = path.join(srcDir, 'temp.bin');
+    fs.writeFileSync(src1, 'DATA');
+    const raw = 'Subject: Combined\r\n\r\nbody';
+
+    const fetchMessage = async (sub) => {
+      if (sub.params.arguments.rawSource) {
+        return makeEnvelope({ rawSource: raw });
+      }
+      return makeEnvelope({ attachments: [{ name: 'doc.txt', filePath: src1 }] });
+    };
+
+    const result = await saveMessageToDisk({
+      args: { messageId: 'mid-7', folderPath: 'fp', destDir: dir, saveAttachments: true },
+      fetchMessage
+    });
+
+    assert.equal(result.emlPath, path.join(dir, 'Combined.eml'));
+    assert.equal(fs.readFileSync(result.emlPath, 'utf8'), raw);
+    assert.deepEqual(result.attachments, [path.join(dir, 'doc.txt')]);
+    assert.equal(fs.readFileSync(path.join(dir, 'doc.txt'), 'utf8'), 'DATA');
+  });
+
+  it('propagates a tool-level { error } from getMessage as a thrown Error', async () => {
+    const dir = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ error: 'Message not found' });
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'missing', folderPath: 'fp', destDir: dir },
+        fetchMessage
+      }),
+      /Message not found/
+    );
+  });
+
+  it('throws when rawSource is missing (no offline copy)', async () => {
+    const dir = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ id: 'mid', subject: 'x' });
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'mid-8', folderPath: 'fp', destDir: dir },
+        fetchMessage
+      }),
+      /offline/i
+    );
+  });
+
+  it('validates required string arguments', async () => {
+    const dir = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny' });
+
+    await assert.rejects(
+      saveMessageToDisk({ args: { folderPath: 'fp', destDir: dir }, fetchMessage }),
+      /messageId/
+    );
+    await assert.rejects(
+      saveMessageToDisk({ args: { messageId: 'm', destDir: dir }, fetchMessage }),
+      /folderPath/
+    );
+    await assert.rejects(
+      saveMessageToDisk({ args: { messageId: 'm', folderPath: 'fp' }, fetchMessage }),
+      /destDir/
+    );
+  });
+});

--- a/test/save-message.test.cjs
+++ b/test/save-message.test.cjs
@@ -4,13 +4,27 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { saveMessageToDisk } = require('../mcp-bridge.cjs');
+const {
+  handleMessage,
+  sanitizeSaveFilename,
+  SAVE_MESSAGE_ENV,
+  SAVE_MESSAGE_TOOL,
+  SAVE_ROOT_ENV,
+  saveMessageToDisk,
+} = require('../mcp-bridge.cjs');
+
+// The tool is opt-in, so every test that expects it to do anything has to turn
+// it on explicitly. Passing env per call (rather than mutating process.env)
+// keeps the tests order-independent.
+const ENABLED = { [SAVE_MESSAGE_ENV]: '1' };
 
 // Tracks temp dirs created during a test so afterEach can remove them.
 let tempDirs = [];
 
 function mkTemp() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tb-mcp-save-'));
+  // realpath because macOS hands out /var/... symlinks for /private/var, and
+  // saveMessageToDisk resolves destDir before returning it.
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tb-mcp-save-')));
   tempDirs.push(dir);
   return dir;
 }
@@ -23,6 +37,15 @@ function makeEnvelope(data) {
     id: 'mock',
     result: { content: [{ type: 'text', text: JSON.stringify(data) }] }
   };
+}
+
+// saveMessageToDisk with the capability gate on by default.
+function save(opts) {
+  return saveMessageToDisk({ env: ENABLED, ...opts });
+}
+
+function modeOf(p) {
+  return fs.lstatSync(p).mode & 0o777;
 }
 
 describe('saveMessageToDisk', () => {
@@ -44,10 +67,10 @@ describe('saveMessageToDisk', () => {
     let seenArgs = null;
     const fetchMessage = async (sub) => {
       seenArgs = sub.params.arguments;
-      return makeEnvelope({ rawSource: raw });
+      return makeEnvelope({ rawSource: raw, subject: 'Hello World' });
     };
 
-    const result = await saveMessageToDisk({
+    const result = await save({
       args: { messageId: 'mid-1', folderPath: 'imap://x/INBOX', destDir: dir },
       fetchMessage
     });
@@ -56,46 +79,69 @@ describe('saveMessageToDisk', () => {
     assert.equal(seenArgs.messageId, 'mid-1');
     const expected = path.join(dir, 'Hello World.eml');
     assert.equal(result.emlPath, expected);
-    assert.equal(fs.readFileSync(expected, 'utf8'), raw);
+    assert.equal(fs.readFileSync(expected, 'latin1'), raw);
     assert.deepEqual(result.attachments, []);
     assert.deepEqual(result.skippedAttachments, []);
     assert.equal(result.destDir, dir);
   });
 
-  it('unfolds a multi-line Subject header when deriving the filename', async () => {
+  it('names the file from the decoded subject field, not the raw Subject header', async () => {
     const dir = mkTemp();
-    const raw = 'From: a@b.com\r\nSubject: First part\r\n continued part\r\n\r\nbody';
+    // Thunderbird hands over mime2DecodedSubject; the raw header still carries
+    // the encoded word. The bridge must not re-derive it from the headers.
+    const raw = 'Subject: =?UTF-8?B?R3LDvMOfZQ==?=\r\n\r\nbody';
 
-    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
-    const result = await saveMessageToDisk({
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw, subject: 'Grüße' });
+    const result = await save({
       args: { messageId: 'mid-2', folderPath: 'fp', destDir: dir },
       fetchMessage
     });
 
-    assert.equal(result.emlPath, path.join(dir, 'First part continued part.eml'));
+    assert.equal(result.emlPath, path.join(dir, 'Grüße.eml'));
     assert.ok(fs.existsSync(result.emlPath));
+  });
+
+  // Regression test for the UTF-8 write that expanded every byte above 0x7f.
+  // rawSource is a Latin-1 byte string, so the bytes on disk must come back
+  // out identical -- 0x80 0xff must not become c2 80 c3 bf.
+  it('writes raw 8-bit bytes unchanged instead of re-encoding them as UTF-8', async () => {
+    const dir = mkTemp();
+    const raw = 'Subject: Binary\r\n\r\n' + Buffer.from([0x80, 0xff, 0xe9, 0x00, 0x7f]).toString('latin1');
+
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw, subject: 'Binary' });
+    const result = await save({
+      args: { messageId: 'mid-bin', folderPath: 'fp', destDir: dir },
+      fetchMessage
+    });
+
+    const onDisk = fs.readFileSync(result.emlPath);
+    assert.deepEqual(
+      [...onDisk.subarray(-5)],
+      [0x80, 0xff, 0xe9, 0x00, 0x7f]
+    );
+    assert.equal(onDisk.length, Buffer.byteLength(raw, 'latin1'));
   });
 
   it('honors emlFilename and appends .eml when absent', async () => {
     const dir = mkTemp();
     const raw = 'Subject: Ignored Subject\r\n\r\nbody';
 
-    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
-    const result = await saveMessageToDisk({
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw, subject: 'Ignored Subject' });
+    const result = await save({
       args: { messageId: 'mid-3', folderPath: 'fp', destDir: dir, emlFilename: 'custom-name' },
       fetchMessage
     });
 
     assert.equal(result.emlPath, path.join(dir, 'custom-name.eml'));
-    assert.equal(fs.readFileSync(result.emlPath, 'utf8'), raw);
+    assert.equal(fs.readFileSync(result.emlPath, 'latin1'), raw);
   });
 
-  it('falls back to messageId when there is no Subject header', async () => {
+  it('falls back to messageId when there is no subject', async () => {
     const dir = mkTemp();
     const raw = 'From: a@b.com\r\n\r\nbody without a subject';
 
     const fetchMessage = async () => makeEnvelope({ rawSource: raw });
-    const result = await saveMessageToDisk({
+    const result = await save({
       args: { messageId: 'fallback-id', folderPath: 'fp', destDir: dir },
       fetchMessage
     });
@@ -103,19 +149,21 @@ describe('saveMessageToDisk', () => {
     assert.equal(result.emlPath, path.join(dir, 'fallback-id.eml'));
   });
 
-  it('creates a missing nested destDir', async () => {
+  it('creates a missing nested destDir, private to the user', async () => {
     const dir = path.join(mkTemp(), 'a', 'b', 'c');
     const raw = 'Subject: Nested\r\n\r\nbody';
 
-    const fetchMessage = async () => makeEnvelope({ rawSource: raw });
-    const result = await saveMessageToDisk({
+    const fetchMessage = async () => makeEnvelope({ rawSource: raw, subject: 'Nested' });
+    const result = await save({
       args: { messageId: 'mid-4', folderPath: 'fp', destDir: dir },
       fetchMessage
     });
 
     assert.ok(fs.existsSync(dir));
     assert.equal(result.emlPath, path.join(dir, 'Nested.eml'));
-    assert.ok(fs.existsSync(result.emlPath));
+    // Saved mail must not be group- or world-readable.
+    assert.equal(modeOf(dir) & 0o077, 0);
+    assert.equal(modeOf(result.emlPath) & 0o077, 0);
   });
 
   it('overwrite:false throws on an existing file, overwrite:true replaces it', async () => {
@@ -123,30 +171,35 @@ describe('saveMessageToDisk', () => {
     const raw1 = 'Subject: Dup\r\n\r\nfirst';
     const raw2 = 'Subject: Dup\r\n\r\nsecond';
 
-    const fetchFirst = async () => makeEnvelope({ rawSource: raw1 });
-    const first = await saveMessageToDisk({
+    const fetchFirst = async () => makeEnvelope({ rawSource: raw1, subject: 'Dup' });
+    const first = await save({
       args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir },
       fetchMessage: fetchFirst
     });
-    assert.equal(fs.readFileSync(first.emlPath, 'utf8'), raw1);
+    assert.equal(fs.readFileSync(first.emlPath, 'latin1'), raw1);
 
-    const fetchSecond = async () => makeEnvelope({ rawSource: raw2 });
+    const fetchSecond = async () => makeEnvelope({ rawSource: raw2, subject: 'Dup' });
     await assert.rejects(
-      saveMessageToDisk({
+      save({
         args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir },
         fetchMessage: fetchSecond
       }),
-      /already exists/
+      (e) => {
+        assert.match(e.message, /already exists/);
+        // The underlying EEXIST is preserved rather than swallowed.
+        assert.equal(e.cause && e.cause.code, 'EEXIST');
+        return true;
+      }
     );
     // The failed non-overwrite write must not have clobbered the original.
-    assert.equal(fs.readFileSync(first.emlPath, 'utf8'), raw1);
+    assert.equal(fs.readFileSync(first.emlPath, 'latin1'), raw1);
 
-    const replaced = await saveMessageToDisk({
+    const replaced = await save({
       args: { messageId: 'mid-5', folderPath: 'fp', destDir: dir, overwrite: true },
       fetchMessage: fetchSecond
     });
     assert.equal(replaced.emlPath, first.emlPath);
-    assert.equal(fs.readFileSync(replaced.emlPath, 'utf8'), raw2);
+    assert.equal(fs.readFileSync(replaced.emlPath, 'latin1'), raw2);
   });
 
   it('copies attachments into destDir by name, suffixes collisions, and skips path-less entries', async () => {
@@ -168,7 +221,7 @@ describe('saveMessageToDisk', () => {
       });
     };
 
-    const result = await saveMessageToDisk({
+    const result = await save({
       args: { messageId: 'mid-6', folderPath: 'fp', destDir: dir, saveEml: false, saveAttachments: true },
       fetchMessage
     });
@@ -178,8 +231,112 @@ describe('saveMessageToDisk', () => {
     assert.deepEqual(result.attachments, [p1, p2]);
     assert.equal(fs.readFileSync(p1, 'utf8'), 'AAA');
     assert.equal(fs.readFileSync(p2, 'utf8'), 'BBB');
+    assert.equal(modeOf(p1) & 0o077, 0);
     assert.deepEqual(result.skippedAttachments, ['inline-only.txt']);
     assert.equal(result.emlPath, null);
+  });
+
+  // Regression test for existsSync + copyFileSync: copyFileSync follows a
+  // symlink at the destination and writes straight through it, so a planted
+  // link turned "save my attachments here" into "overwrite that file there".
+  it('never writes through a symlink planted at the destination', async () => {
+    const dir = mkTemp();
+    const srcDir = mkTemp();
+    const outsideDir = mkTemp();
+    const src = path.join(srcDir, 'temp.bin');
+    const victim = path.join(outsideDir, 'victim.txt');
+    fs.writeFileSync(src, 'ATTACKER BYTES');
+    fs.writeFileSync(victim, 'ORIGINAL');
+    fs.symlinkSync(victim, path.join(dir, 'report.pdf'));
+
+    const fetchMessage = async () => makeEnvelope({
+      attachments: [{ name: 'report.pdf', filePath: src }]
+    });
+
+    const result = await save({
+      args: { messageId: 'mid-sym', folderPath: 'fp', destDir: dir, saveEml: false, saveAttachments: true },
+      fetchMessage
+    });
+
+    // The link counts as a collision, so the copy lands on a suffixed name.
+    assert.deepEqual(result.attachments, [path.join(dir, 'report (2).pdf')]);
+    assert.equal(fs.readFileSync(victim, 'utf8'), 'ORIGINAL');
+  });
+
+  it('replaces the link, not the link target, when overwrite is on', async () => {
+    const dir = mkTemp();
+    const srcDir = mkTemp();
+    const outsideDir = mkTemp();
+    const src = path.join(srcDir, 'temp.bin');
+    const victim = path.join(outsideDir, 'victim.txt');
+    fs.writeFileSync(src, 'NEW BYTES');
+    fs.writeFileSync(victim, 'ORIGINAL');
+    const planted = path.join(dir, 'report.pdf');
+    fs.symlinkSync(victim, planted);
+
+    const fetchMessage = async () => makeEnvelope({
+      attachments: [{ name: 'report.pdf', filePath: src }]
+    });
+
+    const result = await save({
+      args: {
+        messageId: 'mid-sym2', folderPath: 'fp', destDir: dir,
+        saveEml: false, saveAttachments: true, overwrite: true
+      },
+      fetchMessage
+    });
+
+    assert.deepEqual(result.attachments, [planted]);
+    assert.equal(fs.lstatSync(planted).isSymbolicLink(), false);
+    assert.equal(fs.readFileSync(planted, 'utf8'), 'NEW BYTES');
+    assert.equal(fs.readFileSync(victim, 'utf8'), 'ORIGINAL');
+  });
+
+  // overwrite:true used to bypass the used-name set entirely, so a second
+  // attachment with the same name clobbered the first -- and an attachment
+  // named like the .eml clobbered the message written moments earlier.
+  it('overwrite:true still refuses to clobber files written in the same call', async () => {
+    const dir = mkTemp();
+    const srcDir = mkTemp();
+    const src1 = path.join(srcDir, 'a.bin');
+    const src2 = path.join(srcDir, 'b.bin');
+    fs.writeFileSync(src1, 'FIRST');
+    fs.writeFileSync(src2, 'SECOND');
+    const raw = 'Subject: Combined\r\n\r\nmessage body';
+
+    const fetchMessage = async (sub) => {
+      if (sub.params.arguments.rawSource) {
+        return makeEnvelope({ rawSource: raw, subject: 'Combined' });
+      }
+      return makeEnvelope({
+        attachments: [
+          // Same name as the .eml about to be written, then a self-collision.
+          { name: 'Combined.eml', filePath: src1 },
+          { name: 'dup.bin', filePath: src2 },
+          { name: 'dup.bin', filePath: src1 }
+        ]
+      });
+    };
+
+    const result = await save({
+      args: {
+        messageId: 'mid-clobber', folderPath: 'fp', destDir: dir,
+        saveAttachments: true, overwrite: true
+      },
+      fetchMessage
+    });
+
+    // The message survives its own call.
+    assert.equal(fs.readFileSync(result.emlPath, 'latin1'), raw);
+    assert.equal(result.emlPath, path.join(dir, 'Combined.eml'));
+    // Each attachment got its own name.
+    assert.deepEqual(result.attachments, [
+      path.join(dir, 'Combined (2).eml'),
+      path.join(dir, 'dup.bin'),
+      path.join(dir, 'dup (2).bin')
+    ]);
+    assert.equal(fs.readFileSync(path.join(dir, 'dup.bin'), 'utf8'), 'SECOND');
+    assert.equal(fs.readFileSync(path.join(dir, 'dup (2).bin'), 'utf8'), 'FIRST');
   });
 
   it('writes both the .eml and attachments in one call', async () => {
@@ -191,18 +348,18 @@ describe('saveMessageToDisk', () => {
 
     const fetchMessage = async (sub) => {
       if (sub.params.arguments.rawSource) {
-        return makeEnvelope({ rawSource: raw });
+        return makeEnvelope({ rawSource: raw, subject: 'Combined' });
       }
       return makeEnvelope({ attachments: [{ name: 'doc.txt', filePath: src1 }] });
     };
 
-    const result = await saveMessageToDisk({
+    const result = await save({
       args: { messageId: 'mid-7', folderPath: 'fp', destDir: dir, saveAttachments: true },
       fetchMessage
     });
 
     assert.equal(result.emlPath, path.join(dir, 'Combined.eml'));
-    assert.equal(fs.readFileSync(result.emlPath, 'utf8'), raw);
+    assert.equal(fs.readFileSync(result.emlPath, 'latin1'), raw);
     assert.deepEqual(result.attachments, [path.join(dir, 'doc.txt')]);
     assert.equal(fs.readFileSync(path.join(dir, 'doc.txt'), 'utf8'), 'DATA');
   });
@@ -212,7 +369,7 @@ describe('saveMessageToDisk', () => {
     const fetchMessage = async () => makeEnvelope({ error: 'Message not found' });
 
     await assert.rejects(
-      saveMessageToDisk({
+      save({
         args: { messageId: 'missing', folderPath: 'fp', destDir: dir },
         fetchMessage
       }),
@@ -225,7 +382,7 @@ describe('saveMessageToDisk', () => {
     const fetchMessage = async () => makeEnvelope({ id: 'mid', subject: 'x' });
 
     await assert.rejects(
-      saveMessageToDisk({
+      save({
         args: { messageId: 'mid-8', folderPath: 'fp', destDir: dir },
         fetchMessage
       }),
@@ -235,19 +392,191 @@ describe('saveMessageToDisk', () => {
 
   it('validates required string arguments', async () => {
     const dir = mkTemp();
-    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny' });
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny', subject: 'x' });
 
     await assert.rejects(
-      saveMessageToDisk({ args: { folderPath: 'fp', destDir: dir }, fetchMessage }),
+      save({ args: { folderPath: 'fp', destDir: dir }, fetchMessage }),
       /messageId/
     );
     await assert.rejects(
-      saveMessageToDisk({ args: { messageId: 'm', destDir: dir }, fetchMessage }),
+      save({ args: { messageId: 'm', destDir: dir }, fetchMessage }),
       /folderPath/
     );
     await assert.rejects(
-      saveMessageToDisk({ args: { messageId: 'm', folderPath: 'fp' }, fetchMessage }),
+      save({ args: { messageId: 'm', folderPath: 'fp' }, fetchMessage }),
       /destDir/
     );
+  });
+});
+
+describe('saveMessage capability gate', () => {
+  beforeEach(() => {
+    tempDirs = [];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it('refuses to write anything unless explicitly enabled', async () => {
+    const dir = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny', subject: 'x' });
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'm', folderPath: 'fp', destDir: dir },
+        fetchMessage,
+        env: {}
+      }),
+      new RegExp(SAVE_MESSAGE_ENV)
+    );
+    assert.deepEqual(fs.readdirSync(dir), []);
+  });
+
+  it('is absent from tools/list when disabled and present when enabled', async () => {
+    const forward = async () => ({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { tools: [{ name: 'getMessage' }] }
+    });
+    const line = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    const off = await handleMessage(line, { forward, env: {} });
+    assert.deepEqual(off.result.tools.map((t) => t.name), ['getMessage']);
+
+    const on = await handleMessage(line, { forward, env: ENABLED });
+    assert.deepEqual(on.result.tools.map((t) => t.name), ['getMessage', SAVE_MESSAGE_TOOL.name]);
+  });
+
+  it('returns a JSON-RPC error envelope for a disabled tools/call', async () => {
+    const dir = mkTemp();
+    const forward = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny', subject: 'x' });
+    const line = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'tools/call',
+      params: { name: 'saveMessage', arguments: { messageId: 'm', folderPath: 'fp', destDir: dir } }
+    });
+
+    const resp = await handleMessage(line, { forward, env: {} });
+    assert.equal(resp.id, 7);
+    assert.equal(resp.error.code, -32602);
+    assert.match(resp.error.message, new RegExp(SAVE_MESSAGE_ENV));
+    assert.equal(resp.result, undefined);
+    assert.deepEqual(fs.readdirSync(dir), []);
+  });
+
+  it('handles an enabled tools/call through the handler and reports the path', async () => {
+    const dir = mkTemp();
+    const forward = async () => makeEnvelope({ rawSource: 'Subject: Via handler\r\n\r\nbody', subject: 'Via handler' });
+    const line = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'tools/call',
+      params: { name: 'saveMessage', arguments: { messageId: 'm', folderPath: 'fp', destDir: dir } }
+    });
+
+    const resp = await handleMessage(line, { forward, env: ENABLED });
+    assert.equal(resp.error, undefined);
+    const data = JSON.parse(resp.result.content[0].text);
+    assert.equal(data.emlPath, path.join(dir, 'Via handler.eml'));
+    assert.ok(fs.existsSync(data.emlPath));
+  });
+
+  it('confines destDir to THUNDERBIRD_MCP_SAVE_ROOT when one is set', async () => {
+    const root = mkTemp();
+    const outside = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: Rooted\r\n\r\nbody', subject: 'Rooted' });
+    const env = { ...ENABLED, [SAVE_ROOT_ENV]: root };
+
+    const inside = await saveMessageToDisk({
+      args: { messageId: 'm', folderPath: 'fp', destDir: path.join(root, 'sub') },
+      fetchMessage,
+      env
+    });
+    assert.equal(inside.emlPath, path.join(root, 'sub', 'Rooted.eml'));
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'm', folderPath: 'fp', destDir: outside },
+        fetchMessage,
+        env
+      }),
+      new RegExp(SAVE_ROOT_ENV)
+    );
+    assert.deepEqual(fs.readdirSync(outside), []);
+  });
+
+  it('rejects a destDir that escapes the save root through a symlink', async () => {
+    const root = mkTemp();
+    const outside = mkTemp();
+    const escape = path.join(root, 'escape');
+    fs.symlinkSync(outside, escape);
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny', subject: 'x' });
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'm', folderPath: 'fp', destDir: escape },
+        fetchMessage,
+        env: { ...ENABLED, [SAVE_ROOT_ENV]: root }
+      }),
+      new RegExp(SAVE_ROOT_ENV)
+    );
+    assert.deepEqual(fs.readdirSync(outside), []);
+  });
+
+  it('rejects traversal out of the save root', async () => {
+    const root = mkTemp();
+    const fetchMessage = async () => makeEnvelope({ rawSource: 'Subject: x\r\n\r\ny', subject: 'x' });
+
+    await assert.rejects(
+      saveMessageToDisk({
+        args: { messageId: 'm', folderPath: 'fp', destDir: path.join(root, '..') },
+        fetchMessage,
+        env: { ...ENABLED, [SAVE_ROOT_ENV]: root }
+      }),
+      new RegExp(SAVE_ROOT_ENV)
+    );
+  });
+});
+
+describe('sanitizeSaveFilename', () => {
+  it('keeps ordinary names, including unicode and parentheses', () => {
+    assert.equal(sanitizeSaveFilename('Rechnung (final) — Grüße.pdf'), 'Rechnung (final) — Grüße.pdf');
+  });
+
+  it('neutralizes path separators and control characters', () => {
+    assert.equal(sanitizeSaveFilename('../../etc/passwd'), '.. .. etc passwd');
+    assert.equal(sanitizeSaveFilename('a\u0000b'), 'a b');
+    assert.equal(sanitizeSaveFilename('C:\\Windows\\system32'), 'C Windows system32');
+  });
+
+  it('strips the characters Windows forbids, including NTFS stream colons', () => {
+    assert.equal(sanitizeSaveFilename('report:$DATA'), 'report $DATA');
+    assert.equal(sanitizeSaveFilename('a<b>c"d|e?f*g'), 'a b c d e f g');
+  });
+
+  it('drops trailing dots and spaces that Windows silently discards', () => {
+    assert.equal(sanitizeSaveFilename('report.pdf...'), 'report.pdf');
+    assert.equal(sanitizeSaveFilename('report.pdf   '), 'report.pdf');
+  });
+
+  it('defuses reserved device names, with or without an extension', () => {
+    assert.equal(sanitizeSaveFilename('CON'), '_CON');
+    assert.equal(sanitizeSaveFilename('com1.txt'), '_com1.txt');
+    assert.equal(sanitizeSaveFilename('LPT9.tar.gz'), '_LPT9.tar.gz');
+    // Not reserved -- must be left alone.
+    assert.equal(sanitizeSaveFilename('CONTRACT.pdf'), 'CONTRACT.pdf');
+    assert.equal(sanitizeSaveFilename('COM10.txt'), 'COM10.txt');
+  });
+
+  it('refuses names that cannot be made safe', () => {
+    assert.throws(() => sanitizeSaveFilename(''), /Cannot derive/);
+    assert.throws(() => sanitizeSaveFilename('...'), /Cannot derive/);
+    assert.throws(() => sanitizeSaveFilename('/'), /Cannot derive/);
+    assert.throws(() => sanitizeSaveFilename(null), /Cannot derive/);
   });
 });


### PR DESCRIPTION
Replaces #164, which I closed unmerged rather than force-pushing over the branch your review was written against. The first commit here is that PR unchanged; the second addresses all six blockers, so the diff between them is exactly the response to your review.

Thanks for the review — the probes made it a lot easier to act on, and two of the findings were live bugs on my own machine, not just theoretical ones.

## What changed since #164

**1. Default-off capability gate.** `THUNDERBIRD_MCP_SAVE_MESSAGE=1` enables the tool; without it `saveMessage` is absent from `tools/list` and refused at dispatch. `THUNDERBIRD_MCP_SAVE_ROOT` optionally confines every write inside one directory — you said you'd take both, so both are here. `destDir` is resolved through symlinks *before* the containment check, including for directories that don't exist yet (walk up to the nearest existing ancestor, realpath that, re-append the tail), and the resolved path is what everything downstream writes to — checking one path and writing another would have left the hole open.

**2. Latin-1 `.eml` bytes.** Confirmed your finding: `Buffer.from(rawSource, 'latin1')` now. The regression test asserts a raw tail of `80 ff e9 00 7f` survives byte-for-byte.

**3. Collision handling.** `COPYFILE_EXCL` for attachments and `'wx'` for the `.eml`, retrying the ` (n)` suffix on `EEXIST` — the exclusive create *is* the existence check, so the `existsSync` window is gone entirely. `overwrite: true` unlinks first, which gives it no-follow semantics: it replaces the link, never the link's target. The used-name set is now shared between the `.eml` and the attachments and applies in overwrite mode too, so an attachment can no longer clobber a sibling or the message written moments earlier.

**4. Permissions.** Directories `0700`, files `0600`.

**5. Windows-safe naming.** Added `<>:"|?*` (which also closes NTFS alternate-stream colons), trailing dots and spaces, and reserved device stems with or without an extension — `CON`, `com1.txt`, `LPT9.tar.gz` get a `_` prefix, while `CONTRACT.pdf` and `COM10.txt` are left alone. The bridge's RFC 2047 decoder is gone: `getMessage` already returns `mime2DecodedSubject`, so the filename comes from `data.subject`.

**6. Lint and tests.** The rethrown `EEXIST` carries `{ cause }`; `npm run lint` is 0 errors (the 13 remaining warnings are pre-existing and untouched). `handleMessage` gained an injectable `{ forward, env }` seam so the suite now covers the JSON-RPC handler, the `tools/list` injection in both gate states, and the error envelope.

## Verification

`npm test`: 545 tests, 0 failures. saveMessage coverage went 11 → 28 tests.

The three behavioural fixes were each confirmed to **fail** against the pre-fix code before being accepted — reverting `latin1` → `utf8`, dropping `COPYFILE_EXCL`, and restoring the `overwrite` bypass of the used-name set each turns exactly one test red. A test that has never failed doesn't prove much, so I checked.

## One thing worth your call

The gate changes behaviour for anyone already using the tool from #164's branch — after this, `saveMessage` disappears until `THUNDERBIRD_MCP_SAVE_MESSAGE=1` is set. That's the intent, but it's worth a release note. README documents both variables under Security with a sample `mcpServers` env block.