### PR TITLE
[AI-authored] saveDraft: replace an existing draft instead of adding a second copy

### DIFF
--- a/extension/mcp_server/api.js
+++ b/extension/mcp_server/api.js
@@ -1232,10 +1232,12 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
         name: "saveDraft",
         group: "messages", crud: "create",
         title: "Save Draft",
-        description: "Save a composed message to the identity's Drafts folder without sending or opening a compose window. Useful when a human will review and send the message later from Thunderbird.",
+        description: "Save a composed message to the identity's Drafts folder without sending or opening a compose window. Useful when a human will review and send the message later from Thunderbird. Pass replaceMessageId to rewrite an existing draft in place instead of adding a second copy.",
         inputSchema: {
           type: "object",
           properties: {
+            replaceMessageId: { type: "string", description: "Message ID of an existing draft to REPLACE (from searchMessages). The new draft carries the full content given here -- nothing is merged from the old one, so pass every field you want kept. Omit to create a new draft." },
+            replaceFolderPath: { type: "string", description: "Folder URI holding the draft named by replaceMessageId (from searchMessages). Required whenever replaceMessageId is set -- the lookup is folder-scoped, it does not search all folders." },
             to: { type: "string", description: "Recipient email address(es), comma-separated. Optional -- a draft can have no recipient." },
             subject: { type: "string", description: "Email subject line (optional)" },
             body: { type: "string", description: "Email body (optional)" },
@@ -3165,7 +3167,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
              * We try the modern 16-arg call first; if TB throws
              * NS_ERROR_XPC_NOT_ENOUGH_ARGS, fall back to the legacy 18-arg call.
              */
-            function sendMessageDirectly(composeFields, identity, attachDescs, originalMsgURI, compType, deliverMode, bodyType) {
+            function sendMessageDirectly(composeFields, identity, attachDescs, originalMsgURI, compType, deliverMode, bodyType, msgToReplace) {
               if (!identity) {
                 return Promise.resolve({ error: "No identity available for direct send" });
               }
@@ -3276,7 +3278,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                     false,                          // isDigest
                     false,                          // dontDeliver
                     mode,                           // deliver mode
-                    null,                           // msgToReplace
+                    msgToReplace || null,           // msgToReplace
                     bodyMimeType,                   // body type
                     body,                           // body
                   ];
@@ -6521,8 +6523,16 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
              * Saves a composed message to the identity's Drafts folder without
              * sending or opening a compose window. The destination folder is
              * resolved by Thunderbird from the identity's draft-folder pref.
+             *
+             * With replaceMessageId set, the named draft is REPLACED rather than
+             * a second one added: the resolved header goes to createAndSendMessage
+             * as msgToReplace, which is what makes Thunderbird drop the original
+             * once the new draft is written. A draft body cannot be edited in
+             * place through this API surface, so without that argument every
+             * correction of a saved draft would accumulate one more copy in the
+             * Drafts folder, and the caller has no way to remove the stale one.
              */
-            function saveDraft(to, subject, body, cc, bcc, isHtml, from, attachments) {
+            function saveDraft(to, subject, body, cc, bcc, isHtml, from, attachments, replaceMessageId, replaceFolderPath) {
               try {
                 const msgComposeParams = Cc["@mozilla.org/messengercompose/composeparams;1"]
                   .createInstance(Ci.nsIMsgComposeParams);
@@ -6535,13 +6545,32 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 composeFields.bcc = bcc || "";
                 composeFields.subject = subject || "";
 
-                msgComposeParams.type = Ci.nsIMsgCompType.New;
+                // Resolve the draft to replace BEFORE composing anything: an
+                // unresolvable id must fail the whole call, never silently fall
+                // back to appending a second draft -- that failure mode is
+                // indistinguishable from success at the call site.
+                let msgToReplace = null;
+                if (replaceMessageId) {
+                  // findMessage is folder-scoped; without a folder the lookup
+                  // fails as "Folder not found: undefined", which reads like a
+                  // broken folder rather than a missing argument.
+                  if (!replaceFolderPath) {
+                    return { error: "replaceMessageId requires replaceFolderPath (the folder URI from searchMessages)" };
+                  }
+                  const found = findMessage(replaceMessageId, replaceFolderPath);
+                  if (found.error) return { error: found.error };
+                  msgToReplace = found.msgHdr;
+                }
+
+                msgComposeParams.type = replaceMessageId
+                  ? Ci.nsIMsgCompType.Draft
+                  : Ci.nsIMsgCompType.New;
                 msgComposeParams.composeFields = composeFields;
 
                 const identityResult = setComposeIdentity(msgComposeParams, from, null);
                 if (identityResult && identityResult.error) return identityResult;
 
-                const { useHtml, format } = resolveComposeFormat(msgComposeParams.identity, isHtml, Ci.nsIMsgCompType.New);
+                const { useHtml, format } = resolveComposeFormat(msgComposeParams.identity, isHtml, msgComposeParams.type);
                 msgComposeParams.format = format;
                 if (useHtml) {
                   const formatted = formatBodyHtml(body, isHtml);
@@ -6559,12 +6588,13 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                   msgComposeParams.identity,
                   fileDescs,
                   null,
-                  Ci.nsIMsgCompType.New,
+                  msgComposeParams.type,
                   Ci.nsIMsgCompDeliverMode.SaveAsDraft,
-                  useHtml ? "text/html" : "text/plain"
+                  useHtml ? "text/html" : "text/plain",
+                  msgToReplace
                 ).then(result => {
                   if (result.success) {
-                    let msg = "Draft saved";
+                    let msg = msgToReplace ? "Draft replaced" : "Draft saved";
                     if (failedPaths.length > 0) msg += ` (failed to attach: ${failedPaths.join(", ")})`;
                     result.message = msg;
                   }
@@ -8273,7 +8303,7 @@ var mcpServer = class extends ExtensionCommon.ExtensionAPI {
                 case "sendMail":
                   return await composeMail(args.to, args.subject, args.body, args.cc, args.bcc, args.isHtml, args.from, args.attachments, args.skipReview);
                 case "saveDraft":
-                  return await saveDraft(args.to, args.subject, args.body, args.cc, args.bcc, args.isHtml, args.from, args.attachments);
+                  return await saveDraft(args.to, args.subject, args.body, args.cc, args.bcc, args.isHtml, args.from, args.attachments, args.replaceMessageId, args.replaceFolderPath);
                 case "replyToMessage":
                   return await replyToMessage(args.messageId, args.folderPath, args.body, args.replyAll, args.isHtml, args.to, args.cc, args.bcc, args.from, args.attachments, args.skipReview);
                 case "forwardMessage":

--- a/test/save-draft-replace.test.cjs
+++ b/test/save-draft-replace.test.cjs
@@ -1,0 +1,70 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// saveDraft itself needs XPCOM and cannot run here. What CAN be checked without
+// Thunderbird is the wiring, and that is where the silent defect lives: a
+// parameter declared in inputSchema but never forwarded at the dispatch switch
+// is accepted by the client, validated, and then dropped -- the call succeeds
+// and quietly does the old thing. Reading the real api.js is the point; a
+// mirrored copy of the dispatch line would move with the bug.
+const API_PATH = path.join(__dirname, "..", "extension", "mcp_server", "api.js");
+const source = fs.readFileSync(API_PATH, "utf8");
+
+function saveDraftToolDefinition() {
+  const start = source.indexOf('name: "saveDraft"');
+  assert.notEqual(start, -1, "saveDraft tool definition not found in api.js");
+  // Definitions are separated by the next tool's name key.
+  const next = source.indexOf("name: \"", start + 20);
+  return source.slice(start, next === -1 ? source.length : next);
+}
+
+function saveDraftDispatchLine() {
+  const marker = 'case "saveDraft":';
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, "saveDraft dispatch case not found in api.js");
+  const end = source.indexOf(";", start + marker.length);
+  return source.slice(start, end);
+}
+
+describe("saveDraft replace-draft wiring", () => {
+  const params = ["replaceMessageId", "replaceFolderPath"];
+
+  it("declares both replace parameters in the tool schema", () => {
+    const def = saveDraftToolDefinition();
+    for (const p of params) {
+      assert.ok(def.includes(`${p}:`), `inputSchema is missing ${p}`);
+    }
+  });
+
+  it("forwards both replace parameters at the dispatch switch", () => {
+    const line = saveDraftDispatchLine();
+    for (const p of params) {
+      assert.ok(
+        line.includes(`args.${p}`),
+        `dispatch drops ${p}: a caller can set it and nothing happens`
+      );
+    }
+  });
+
+  // Known-negative control: proves the assertions above discriminate rather
+  // than matching anything that happens to be in the file. A parameter that
+  // was never added must NOT be reported as wired.
+  it("does not report an absent parameter as wired", () => {
+    const def = saveDraftToolDefinition();
+    const line = saveDraftDispatchLine();
+    assert.ok(!def.includes("replaceNothingAtAll:"));
+    assert.ok(!line.includes("args.replaceNothingAtAll"));
+  });
+
+  it("scopes the reads to saveDraft, not the whole file", () => {
+    // A slice that ran to EOF would make every assertion pass for the wrong
+    // reason -- some other tool's schema would satisfy it.
+    const def = saveDraftToolDefinition();
+    assert.ok(def.length < source.length / 4, "tool definition slice is too wide to be saveDraft's");
+    assert.ok(!def.includes('name: "listCalendars"'), "slice leaked into the next tool definition");
+  });
+});


### PR DESCRIPTION
## Problem

`saveDraft` always composed with `nsIMsgCompType.New`, so a draft body could not be
edited through this API surface. Every correction of a saved draft left the stale
version behind and the caller had no way to remove it — correcting six drafts in one
session produced twelve, and a human then had to tell the good ones from the bad by
hand.

## Change

The mechanism was already plumbed: `createAndSendMessage` takes a `msgToReplace`
header at position 8, which `sendMessageDirectly` passed as `null`. `saveDraft` now
accepts optional `replaceMessageId` + `replaceFolderPath`, resolves the header through
the existing `findMessage` helper, composes as `Draft` rather than `New`, and hands
the header down to be replaced.

Resolution happens **before** anything is composed. An unresolvable id fails the whole
call rather than falling back to appending a second draft, because that fallback is
indistinguishable from success at the call site. `replaceFolderPath` is required
alongside `replaceMessageId` and says so: `findMessage` is folder-scoped, and omitting
it would otherwise surface as `Folder not found: undefined`, which reads like a broken
folder rather than a missing argument.

Two files, no behaviour change on the existing path: `extension/mcp_server/api.js` and
a new `test/save-draft-replace.test.cjs`.

### One change that rides along, and why it is neutral

`resolveComposeFormat`'s third argument moves from a hardcoded `Ci.nsIMsgCompType.New`
to `msgComposeParams.type`. That function branches on `compType` only for
`ForwardInline` / `ForwardAsAttachment`; `Draft` takes the same `else` path `New` did.
So the swap changes nothing for either the new or the existing case — it just stops the
value being stated twice.

## Verification

**Static.** Suite 521 tests / 0 fail (504 pass, 17 skipped); `eslint .` 0 errors,
13 warnings — the same 13 with the same per-file distribution as `main`, so this branch
introduces no new lint finding. Both measured in an isolated worktree checked out at
this branch, with the worktree proven to resolve the project's own `api.js`.

The added test reads the real `api.js` rather than mirroring it, because the defect it
guards is a parameter declared in `inputSchema` but dropped at the dispatch switch — the
client validates it, the call succeeds, and nothing happens. A mirrored copy would move
with that bug. Red-first: baseline green on all four assertions; removing
`args.replaceFolderPath` from the dispatch line turns the dispatch assertion red while
the schema assertion stays green, so the red is attributable to the planted defect
rather than to a blanket failure. The test carries a known-negative control (a parameter
that was never added must not be reported as wired) and a slice-width assertion, so the
reads cannot pass by matching some other tool's schema.

**Runtime**, against a live Thunderbird — the part the source cannot answer, namely
whether Thunderbird actually drops the original on `SaveAsDraft` with `msgToReplace`
set. Driven directly against the running extension, with `tools/list` first confirming
the extension serves both new parameters (controlled with a known-present parameter, so
an empty result could not pass as absence):

- *Replace.* Baseline taken immediately before: 0 marker drafts, folder 152. Created
  `PROBE-EDITDRAFT-alt`, replaced it with subject `PROBE-EDITDRAFT-neu` → response
  `Draft replaced`; exactly one version survives (delta 0 against the post-create
  state), it carries the **new** subject, and the old message id is gone. The three
  together exclude the case where the new draft was never written and only the old one
  remained — which a bare count would not have distinguished.
- *Unresolvable id.* Response `Message not found: …`; no second draft was created
  (marker count 1 before, 1 after). The resolve-before-compose guard is exercised, not
  merely intended.

Probe drafts removed afterwards; folder count back to 152, its pre-probe value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
